### PR TITLE
Backport of RAM from JDK Tip to JDK21

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -29,6 +29,7 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/stackValue.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaThread.hpp"
@@ -80,6 +81,20 @@ ScopeValue* DebugInfoReadStream::read_object_value(bool is_auto_box) {
   return result;
 }
 
+ScopeValue* DebugInfoReadStream::read_object_merge_value() {
+  int id = read_int();
+#ifdef ASSERT
+  assert(_obj_pool != nullptr, "object pool does not exist");
+  for (int i = _obj_pool->length() - 1; i >= 0; i--) {
+    assert(_obj_pool->at(i)->as_ObjectValue()->id() != id, "should not be read twice");
+  }
+#endif
+  ObjectMergeValue* result = new ObjectMergeValue(id);
+  _obj_pool->push(result);
+  result->read_object(this);
+  return result;
+}
+
 ScopeValue* DebugInfoReadStream::get_cached_object() {
   int id = read_int();
   assert(_obj_pool != nullptr, "object pool does not exist");
@@ -98,7 +113,8 @@ ScopeValue* DebugInfoReadStream::get_cached_object() {
 enum { LOCATION_CODE = 0, CONSTANT_INT_CODE = 1,  CONSTANT_OOP_CODE = 2,
                           CONSTANT_LONG_CODE = 3, CONSTANT_DOUBLE_CODE = 4,
                           OBJECT_CODE = 5,        OBJECT_ID_CODE = 6,
-                          AUTO_BOX_OBJECT_CODE = 7, MARKER_CODE = 8 };
+                          AUTO_BOX_OBJECT_CODE = 7, MARKER_CODE = 8,
+                          OBJECT_MERGE_CODE = 9 };
 
 ScopeValue* ScopeValue::read_from(DebugInfoReadStream* stream) {
   ScopeValue* result = nullptr;
@@ -110,6 +126,7 @@ ScopeValue* ScopeValue::read_from(DebugInfoReadStream* stream) {
    case CONSTANT_DOUBLE_CODE: result = new ConstantDoubleValue(stream);                  break;
    case OBJECT_CODE:          result = stream->read_object_value(false /*is_auto_box*/); break;
    case AUTO_BOX_OBJECT_CODE: result = stream->read_object_value(true /*is_auto_box*/);  break;
+   case OBJECT_MERGE_CODE:    result = stream->read_object_merge_value();                break;
    case OBJECT_ID_CODE:       result = stream->get_cached_object();                      break;
    case MARKER_CODE:          result = new MarkerValue();                                break;
    default: ShouldNotReachHere();
@@ -149,6 +166,7 @@ void ObjectValue::set_value(oop value) {
 }
 
 void ObjectValue::read_object(DebugInfoReadStream* stream) {
+  _is_root = stream->read_bool();
   _klass = read_from(stream);
   assert(_klass->is_constant_oop(), "should be constant java mirror oop");
   int length = stream->read_int();
@@ -166,6 +184,7 @@ void ObjectValue::write_on(DebugInfoWriteStream* stream) {
     set_visited(true);
     stream->write_int(is_auto_box() ? AUTO_BOX_OBJECT_CODE : OBJECT_CODE);
     stream->write_int(_id);
+    stream->write_bool(_is_root);
     _klass->write_on(stream);
     int length = _field_values.length();
     stream->write_int(length);
@@ -176,7 +195,7 @@ void ObjectValue::write_on(DebugInfoWriteStream* stream) {
 }
 
 void ObjectValue::print_on(outputStream* st) const {
-  st->print("%s[%d]", is_auto_box() ? "box_obj" : "obj", _id);
+  st->print("%s[%d]", is_auto_box() ? "box_obj" : is_object_merge() ? "merge_obj" : "obj", _id);
 }
 
 void ObjectValue::print_fields_on(outputStream* st) const {
@@ -189,6 +208,69 @@ void ObjectValue::print_fields_on(outputStream* st) const {
     _field_values.at(i)->print_on(st);
   }
 #endif
+}
+
+
+// ObjectMergeValue
+
+// Returns the ObjectValue that should be used for the local that this
+// ObjectMergeValue represents. ObjectMergeValue represents allocation
+// merges in C2. This method will select which path the allocation merge
+// took during execution of the Trap that triggered the rematerialization
+// of the object.
+ObjectValue* ObjectMergeValue::select(frame& fr, RegisterMap& reg_map) {
+  StackValue* sv_selector = StackValue::create_stack_value(&fr, &reg_map, _selector);
+  jint selector = sv_selector->get_jint();
+
+  // If the selector is '-1' it means that execution followed the path
+  // where no scalar replacement happened.
+  // Otherwise, it is the index in _possible_objects array that holds
+  // the description of the scalar replaced object.
+  if (selector == -1) {
+    StackValue* sv_merge_pointer = StackValue::create_stack_value(&fr, &reg_map, _merge_pointer);
+    _selected = new ObjectValue(id());
+
+    // Retrieve the pointer to the real object and use it as if we had
+    // allocated it during the deoptimization
+    _selected->set_value(sv_merge_pointer->get_obj()());
+
+    // No need to rematerialize
+    return nullptr;
+  } else {
+    assert(selector < _possible_objects.length(), "sanity");
+    _selected = (ObjectValue*) _possible_objects.at(selector);
+    return _selected;
+  }
+}
+
+void ObjectMergeValue::read_object(DebugInfoReadStream* stream) {
+  _selector = read_from(stream);
+  _merge_pointer = read_from(stream);
+  int ncandidates = stream->read_int();
+  for (int i = 0; i < ncandidates; i++) {
+    ScopeValue* result = read_from(stream);
+    assert(result->is_object(), "Candidate is not an object!");
+    ObjectValue* obj = result->as_ObjectValue();
+    _possible_objects.append(obj);
+  }
+}
+
+void ObjectMergeValue::write_on(DebugInfoWriteStream* stream) {
+  if (is_visited()) {
+    stream->write_int(OBJECT_ID_CODE);
+    stream->write_int(_id);
+  } else {
+    set_visited(true);
+    stream->write_int(OBJECT_MERGE_CODE);
+    stream->write_int(_id);
+    _selector->write_on(stream);
+    _merge_pointer->write_on(stream);
+    int ncandidates = _possible_objects.length();
+    stream->write_int(ncandidates);
+    for (int i = 0; i < ncandidates; i++) {
+      _possible_objects.at(i)->as_ObjectValue()->write_on(stream);
+    }
+  }
 }
 
 // ConstantIntValue

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -44,12 +44,14 @@ class ConstantOopReadValue;
 class ConstantOopWriteValue;
 class LocationValue;
 class ObjectValue;
+class ObjectMergeValue;
 
 class ScopeValue: public AnyObj {
  public:
   // Testers
   virtual bool is_location() const { return false; }
   virtual bool is_object() const { return false; }
+  virtual bool is_object_merge() const { return false; }
   virtual bool is_auto_box() const { return false; }
   virtual bool is_marker() const { return false; }
   virtual bool is_constant_int() const { return false; }
@@ -71,6 +73,11 @@ class ScopeValue: public AnyObj {
   ObjectValue* as_ObjectValue() {
     assert(is_object(), "must be");
     return (ObjectValue*)this;
+  }
+
+  ObjectMergeValue* as_ObjectMergeValue() {
+    assert(is_object_merge(), "must be");
+    return (ObjectMergeValue*)this;
   }
 
   LocationValue* as_LocationValue() {
@@ -126,13 +133,18 @@ class ObjectValue: public ScopeValue {
   GrowableArray<ScopeValue*> _field_values;
   Handle                     _value;
   bool                       _visited;
+  bool                       _is_root;   // Will be true if this object is referred to
+                                         // as a local/expression/monitor in the JVMs.
+                                         // Otherwise false, meaning it's just a candidate
+                                         // in an object allocation merge.
  public:
   ObjectValue(int id, ScopeValue* klass)
      : _id(id)
      , _klass(klass)
      , _field_values()
      , _value()
-     , _visited(false) {
+     , _visited(false)
+     , _is_root(true) {
     assert(klass->is_constant_oop(), "should be constant java mirror oop");
   }
 
@@ -141,20 +153,24 @@ class ObjectValue: public ScopeValue {
      , _klass(nullptr)
      , _field_values()
      , _value()
-     , _visited(false) {}
+     , _visited(false)
+     , _is_root(true) {}
 
   // Accessors
-  bool                        is_object() const         { return true; }
-  int                         id() const                { return _id; }
-  ScopeValue*                 klass() const             { return _klass; }
-  GrowableArray<ScopeValue*>* field_values()            { return &_field_values; }
-  ScopeValue*                 field_at(int i) const     { return _field_values.at(i); }
-  int                         field_size()              { return _field_values.length(); }
-  Handle                      value() const             { return _value; }
-  bool                        is_visited() const        { return _visited; }
+  bool                        is_object() const           { return true; }
+  int                         id() const                  { return _id; }
+  virtual ScopeValue*         klass() const               { return _klass; }
+  virtual GrowableArray<ScopeValue*>* field_values()      { return &_field_values; }
+  virtual ScopeValue*         field_at(int i) const       { return _field_values.at(i); }
+  virtual int                 field_size()                { return _field_values.length(); }
+  virtual Handle              value() const               { return _value; }
+  bool                        is_visited() const          { return _visited; }
+  bool                        is_root() const             { return _is_root; }
 
-  void                        set_value(oop value);
-  void                        set_visited(bool visited) { _visited = visited; }
+  void                        set_id(int id)              { _id = id; }
+  virtual void                set_value(oop value);
+  void                        set_visited(bool visited)   { _visited = visited; }
+  void                        set_root(bool root)         { _is_root = root; }
 
   // Serialization of debugging information
   void read_object(DebugInfoReadStream* stream);
@@ -163,6 +179,65 @@ class ObjectValue: public ScopeValue {
   // Printing
   void print_on(outputStream* st) const;
   void print_fields_on(outputStream* st) const;
+};
+
+// An ObjectMergeValue describes objects that were inputs to a Phi in C2 and at
+// least one of them was scalar replaced.
+// '_selector' is an integer value that will be '-1' if during the execution of
+// the C2 compiled code the path taken was that of the Phi input that was NOT
+// scalar replaced. In that case '_merge_pointer' is a pointer to an already
+// allocated object. If '_selector' is not '-1' then it should be the index of
+// an object in '_possible_objects'. That object is an ObjectValue describing an
+// object that was scalar replaced.
+
+class ObjectMergeValue: public ObjectValue {
+protected:
+  ScopeValue*                _selector;
+  ScopeValue*                _merge_pointer;
+  GrowableArray<ScopeValue*> _possible_objects;
+
+  // This holds the ObjectValue that should be used in place of this
+  // ObjectMergeValue. I.e., it's the ScopeValue from _possible_objects that was
+  // selected by 'select()' or is a on-the-fly created ScopeValue representing
+  // the _merge_pointer if _selector is -1.
+  //
+  // We need to keep this reference around because there will be entries in
+  // ScopeDesc that reference this ObjectMergeValue directly. After
+  // rematerialization ObjectMergeValue will be just a wrapper for the
+  // Objectvalue pointed by _selected.
+  ObjectValue*               _selected;
+public:
+  ObjectMergeValue(int id, ScopeValue* merge_pointer, ScopeValue* selector)
+     : ObjectValue(id)
+     , _selector(selector)
+     , _merge_pointer(merge_pointer)
+     , _possible_objects()
+     , _selected(nullptr) {}
+
+  ObjectMergeValue(int id)
+     : ObjectValue(id)
+     , _selector(nullptr)
+     , _merge_pointer(nullptr)
+     , _possible_objects()
+     , _selected(nullptr) {}
+
+  bool                        is_object_merge() const         { return true; }
+  ScopeValue*                 selector() const                { return _selector; }
+  ScopeValue*                 merge_pointer() const           { return _merge_pointer; }
+  GrowableArray<ScopeValue*>* possible_objects()              { return &_possible_objects; }
+  ObjectValue*                select(frame& fr, RegisterMap& reg_map) ;
+
+  ScopeValue*                 klass() const                   { ShouldNotReachHere(); return nullptr; }
+  GrowableArray<ScopeValue*>* field_values()                  { ShouldNotReachHere(); return nullptr; }
+  ScopeValue*                 field_at(int i) const           { ShouldNotReachHere(); return nullptr; }
+  int                         field_size()                    { ShouldNotReachHere(); return -1; }
+
+  Handle                      value() const                   { assert(_selected != nullptr, "Should call select() first."); return _selected->value(); }
+  void                        set_value(oop value)            { assert(_selected != nullptr, "Should call select() first."); _selected->set_value(value); }
+
+  // Serialization of debugging information
+  void read_object(DebugInfoReadStream* stream);
+  void write_on(DebugInfoWriteStream* stream);
 };
 
 class AutoBoxObjectValue : public ObjectValue {
@@ -316,6 +391,7 @@ class DebugInfoReadStream : public CompressedReadStream {
     return o;
   }
   ScopeValue* read_object_value(bool is_auto_box);
+  ScopeValue* read_object_merge_value();
   ScopeValue* get_cached_object();
   // BCI encoding is mostly unsigned, but -1 is a distinguished value
   int read_bci() { return read_int() + InvocationEntryBci; }

--- a/src/hotspot/share/code/scopeDesc.hpp
+++ b/src/hotspot/share/code/scopeDesc.hpp
@@ -134,6 +134,7 @@ class ScopeDesc : public ResourceObj {
  public:
   // Verification
   void verify();
+  GrowableArray<ScopeValue*>* objects_to_rematerialize(frame& frm, RegisterMap& map);
 
 #ifndef PRODUCT
  public:

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1498,6 +1498,7 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
             GrowableArray<ScopeValue*>* local_values = scope->locals();
             for (int i = 0; i < local_values->length(); i++) {
               ScopeValue* value = local_values->at(i);
+              assert(!value->is_object_merge(), "Should not be.");
               if (value->is_object()) {
                 if (localIsVirtual_h.is_null()) {
                   typeArrayOop array_oop = oopFactory::new_boolArray(local_values->length(), CHECK_NULL);
@@ -1740,6 +1741,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
     if (locals != nullptr) {
       for (int i2 = 0; i2 < locals->size(); i2++) {
         StackValue* var = locals->at(i2);
+        assert(!scopedValues->at(i2)->is_object_merge(), "Should not be.");
         if (var->type() == T_OBJECT && scopedValues->at(i2)->is_object()) {
           jvalue val;
           val.l = cast_from_oop<jobject>(locals->at(i2)->get_obj()());
@@ -1753,6 +1755,7 @@ C2V_VMENTRY(void, materializeVirtualObjects, (JNIEnv* env, jobject, jobject _hs_
     if (expressions != nullptr) {
       for (int i2 = 0; i2 < expressions->size(); i2++) {
         StackValue* var = expressions->at(i2);
+        assert(!scopeExpressions->at(i2)->is_object_merge(), "Should not be.");
         if (var->type() == T_OBJECT && scopeExpressions->at(i2)->is_object()) {
           jvalue val;
           val.l = cast_from_oop<jobject>(expressions->at(i2)->get_obj()());

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -470,6 +470,12 @@
   develop(bool, TracePostallocExpand, false, "Trace expanding nodes after"  \
           " register allocation.")                                          \
                                                                             \
+  product(bool, ReduceAllocationMerges, true, DIAGNOSTIC,                   \
+          "Try to simplify allocation merges before Scalar Replacement")    \
+                                                                            \
+  notproduct(bool, TraceReduceAllocationMerges, false,                      \
+          "Trace decision for simplifying allocation merges.")              \
+                                                                            \
   product(bool, DoEscapeAnalysis, true,                                     \
           "Perform escape analysis")                                        \
                                                                             \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -55,6 +55,9 @@ const char* C2Compiler::retry_no_iterative_escape_analysis() {
 const char* C2Compiler::retry_class_loading_during_parsing() {
   return "retry class loading during parsing";
 }
+const char* C2Compiler::retry_no_reduce_allocation_merges() {
+  return "retry without reducing allocation merges";
+}
 
 void compiler_stubs_init(bool in_compiler_thread);
 
@@ -109,12 +112,13 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool subsume_loads = SubsumeLoads;
   bool do_escape_analysis = DoEscapeAnalysis;
   bool do_iterative_escape_analysis = DoEscapeAnalysis;
+  bool do_reduce_allocation_merges = ReduceAllocationMerges && EliminateAllocations;
   bool eliminate_boxing = EliminateAutoBox;
   bool do_locks_coarsening = EliminateLocks;
 
   while (!env->failing()) {
     // Attempt to compile while subsuming loads into machine instructions.
-    Options options(subsume_loads, do_escape_analysis, do_iterative_escape_analysis, eliminate_boxing, do_locks_coarsening, install_code);
+    Options options(subsume_loads, do_escape_analysis, do_iterative_escape_analysis, do_reduce_allocation_merges, eliminate_boxing, do_locks_coarsening, install_code);
     Compile C(env, target, entry_bci, options, directive);
 
     // Check result and retry if appropriate.
@@ -138,6 +142,12 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
       if (C.failure_reason_is(retry_no_iterative_escape_analysis())) {
         assert(do_iterative_escape_analysis, "must make progress");
         do_iterative_escape_analysis = false;
+        env->report_failure(C.failure_reason());
+        continue;  // retry
+      }
+      if (C.failure_reason_is(retry_no_reduce_allocation_merges())) {
+        assert(do_reduce_allocation_merges, "must make progress");
+        do_reduce_allocation_merges = false;
         env->report_failure(C.failure_reason());
         continue;  // retry
       }

--- a/src/hotspot/share/opto/c2compiler.hpp
+++ b/src/hotspot/share/opto/c2compiler.hpp
@@ -50,6 +50,7 @@ public:
   static const char* retry_no_subsuming_loads();
   static const char* retry_no_escape_analysis();
   static const char* retry_no_iterative_escape_analysis();
+  static const char* retry_no_reduce_allocation_merges();
   static const char* retry_no_locks_coarsening();
   static const char* retry_class_loading_during_parsing();
 

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1103,13 +1103,16 @@ Node* CallStaticJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return CallNode::Ideal(phase, can_reshape);
 }
 
+//----------------------------is_uncommon_trap----------------------------
+// Returns true if this is an uncommon trap.
+bool CallStaticJavaNode::is_uncommon_trap() const {
+  return (_name != nullptr && !strcmp(_name, "uncommon_trap"));
+}
+
 //----------------------------uncommon_trap_request----------------------------
 // If this is an uncommon trap, return the request code, else zero.
 int CallStaticJavaNode::uncommon_trap_request() const {
-  if (_name != nullptr && !strcmp(_name, "uncommon_trap")) {
-    return extract_uncommon_trap_request(this);
-  }
-  return 0;
+  return is_uncommon_trap() ? extract_uncommon_trap_request(this) : 0;
 }
 int CallStaticJavaNode::extract_uncommon_trap_request(const Node* call) {
 #ifndef PRODUCT
@@ -1460,22 +1463,14 @@ void SafePointNode::disconnect_from_root(PhaseIterGVN *igvn) {
 
 //==============  SafePointScalarObjectNode  ==============
 
-SafePointScalarObjectNode::SafePointScalarObjectNode(const TypeOopPtr* tp,
-#ifdef ASSERT
-                                                     Node* alloc,
-#endif
-                                                     uint first_index,
-                                                     uint n_fields) :
+SafePointScalarObjectNode::SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint n_fields) :
   TypeNode(tp, 1), // 1 control input -- seems required.  Get from root.
   _first_index(first_index),
-  _n_fields(n_fields)
-#ifdef ASSERT
-  , _alloc(alloc)
-#endif
+  _n_fields(n_fields),
+  _alloc(alloc)
 {
 #ifdef ASSERT
-  if (!alloc->is_Allocate()
-      && !(alloc->Opcode() == Op_VectorBox)) {
+  if (!alloc->is_Allocate() && !(alloc->Opcode() == Op_VectorBox)) {
     alloc->dump();
     assert(false, "unexpected call node");
   }
@@ -1521,10 +1516,58 @@ SafePointScalarObjectNode::clone(Dict* sosn_map, bool& new_node) const {
 
 #ifndef PRODUCT
 void SafePointScalarObjectNode::dump_spec(outputStream *st) const {
-  st->print(" # fields@[%d..%d]", first_index(),
-             first_index() + n_fields() - 1);
+  st->print(" # fields@[%d..%d]", first_index(), first_index() + n_fields() - 1);
+}
+#endif
+
+//==============  SafePointScalarMergeNode  ==============
+
+SafePointScalarMergeNode::SafePointScalarMergeNode(const TypeOopPtr* tp, int merge_pointer_idx) :
+  TypeNode(tp, 1), // 1 control input -- seems required.  Get from root.
+  _merge_pointer_idx(merge_pointer_idx)
+{
+  init_class_id(Class_SafePointScalarMerge);
 }
 
+// Do not allow value-numbering for SafePointScalarMerge node.
+uint SafePointScalarMergeNode::hash() const { return NO_HASH; }
+bool SafePointScalarMergeNode::cmp( const Node &n ) const {
+  return (&n == this); // Always fail except on self
+}
+
+uint SafePointScalarMergeNode::ideal_reg() const {
+  return 0; // No matching to machine instruction
+}
+
+const RegMask &SafePointScalarMergeNode::in_RegMask(uint idx) const {
+  return *(Compile::current()->matcher()->idealreg2debugmask[in(idx)->ideal_reg()]);
+}
+
+const RegMask &SafePointScalarMergeNode::out_RegMask() const {
+  return RegMask::Empty;
+}
+
+uint SafePointScalarMergeNode::match_edge(uint idx) const {
+  return 0;
+}
+
+SafePointScalarMergeNode*
+SafePointScalarMergeNode::clone(Dict* sosn_map, bool& new_node) const {
+  void* cached = (*sosn_map)[(void*)this];
+  if (cached != nullptr) {
+    new_node = false;
+    return (SafePointScalarMergeNode*)cached;
+  }
+  new_node = true;
+  SafePointScalarMergeNode* res = (SafePointScalarMergeNode*)Node::clone();
+  sosn_map->Insert((void*)this, (void*)res);
+  return res;
+}
+
+#ifndef PRODUCT
+void SafePointScalarMergeNode::dump_spec(outputStream *st) const {
+  st->print(" # merge_pointer_idx=%d, scalarized_objects=%d", _merge_pointer_idx, req()-1);
+}
 #endif
 
 //=============================================================================

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -505,25 +505,22 @@ public:
 //------------------------------SafePointScalarObjectNode----------------------
 // A SafePointScalarObjectNode represents the state of a scalarized object
 // at a safepoint.
-
 class SafePointScalarObjectNode: public TypeNode {
-  uint _first_index; // First input edge relative index of a SafePoint node where
-                     // states of the scalarized object fields are collected.
-                     // It is relative to the last (youngest) jvms->_scloff.
-  uint _n_fields;    // Number of non-static fields of the scalarized object.
-  DEBUG_ONLY(Node* _alloc;)
+  uint _first_index;              // First input edge relative index of a SafePoint node where
+                                  // states of the scalarized object fields are collected.
+                                  // It is relative to the last (youngest) jvms->_scloff.
+  uint _n_fields;                 // Number of non-static fields of the scalarized object.
 
-  virtual uint hash() const ; // { return NO_HASH; }
+  Node* _alloc;                   // Just for debugging purposes.
+
+  virtual uint hash() const;
   virtual bool cmp( const Node &n ) const;
 
   uint first_index() const { return _first_index; }
 
 public:
-  SafePointScalarObjectNode(const TypeOopPtr* tp,
-#ifdef ASSERT
-                            Node* alloc,
-#endif
-                            uint first_index, uint n_fields);
+  SafePointScalarObjectNode(const TypeOopPtr* tp, Node* alloc, uint first_index, uint n_fields);
+
   virtual int Opcode() const;
   virtual uint           ideal_reg() const;
   virtual const RegMask &in_RegMask(uint) const;
@@ -556,6 +553,92 @@ public:
 #endif
 };
 
+//------------------------------SafePointScalarMergeNode----------------------
+//
+// This class represents an allocation merge that is used as debug information
+// and had at least one of its input scalar replaced.
+//
+// The required inputs of this node, except the control, are pointers to
+// SafePointScalarObjectNodes that describe scalarized inputs of the original
+// allocation merge. The other(s) properties of the class are described below.
+//
+// _merge_pointer_idx : index in the SafePointNode's input array where the
+//   description of the _allocation merge_ starts. The index is zero based and
+//   relative to the SafePoint's scloff. The two entries in the SafePointNode's
+//   input array starting at '_merge_pointer_idx` are Phi nodes representing:
+//
+//   1) The original merge Phi. During rematerialization this input will only be
+//   used if the "selector Phi" (see below) indicates that the execution of the
+//   Phi took the path of a non scalarized input.
+//
+//   2) A "selector Phi". The output of this Phi will be '-1' if the execution
+//   of the method exercised a non scalarized input of the original Phi.
+//   Otherwise, the output will be >=0, and it will indicate the index-1 in the
+//   SafePointScalarMergeNode input array where the description of the
+//   scalarized object that should be used is.
+//
+// As an example, consider a Phi merging 3 inputs, of which the last 2 are
+// scalar replaceable.
+//
+//    Phi(Region, NSR, SR, SR)
+//
+// During scalar replacement the SR inputs will be changed to null:
+//
+//    Phi(Region, NSR, nullptr, nullptr)
+//
+// A corresponding selector Phi will be created with a configuration like this:
+//
+//    Phi(Region, -1, 0, 1)
+//
+// During execution of the compiled method, if the execution reaches a Trap, the
+// output of the selector Phi will tell if we need to rematerialize one of the
+// scalar replaced inputs or if we should just use the pointer returned by the
+// original Phi.
+
+class SafePointScalarMergeNode: public TypeNode {
+  int _merge_pointer_idx;         // This is the first input edge relative
+                                  // index of a SafePoint node where metadata information relative
+                                  // to restoring the merge is stored. The corresponding input
+                                  // in the associated SafePoint will point to a Phi representing
+                                  // potential non-scalar replaced objects.
+
+  virtual uint hash() const;
+  virtual bool cmp( const Node &n ) const;
+
+public:
+  SafePointScalarMergeNode(const TypeOopPtr* tp, int merge_pointer_idx);
+
+  virtual int            Opcode() const;
+  virtual uint           ideal_reg() const;
+  virtual const RegMask &in_RegMask(uint) const;
+  virtual const RegMask &out_RegMask() const;
+  virtual uint           match_edge(uint idx) const;
+
+  virtual uint size_of() const { return sizeof(*this); }
+
+  int merge_pointer_idx(JVMState* jvms) const {
+    assert(jvms != nullptr, "JVMS reference is null.");
+    return jvms->scloff() + _merge_pointer_idx;
+  }
+
+  int selector_idx(JVMState* jvms) const {
+    assert(jvms != nullptr, "JVMS reference is null.");
+    return jvms->scloff() + _merge_pointer_idx + 1;
+  }
+
+  // Assumes that "this" is an argument to a safepoint node "s", and that
+  // "new_call" is being created to correspond to "s".  But the difference
+  // between the start index of the jvmstates of "new_call" and "s" is
+  // "jvms_adj".  Produce and return a SafePointScalarObjectNode that
+  // corresponds appropriately to "this" in "new_call".  Assumes that
+  // "sosn_map" is a map, specific to the translation of "s" to "new_call",
+  // mapping old SafePointScalarObjectNodes to new, to avoid multiple copies.
+  SafePointScalarMergeNode* clone(Dict* sosn_map, bool& new_node) const;
+
+#ifndef PRODUCT
+  virtual void              dump_spec(outputStream *st) const;
+#endif
+};
 
 // Simple container for the outgoing projections of a call.  Useful
 // for serious surgery on calls.
@@ -735,6 +818,7 @@ public:
 
   // If this is an uncommon trap, return the request code, else zero.
   int uncommon_trap_request() const;
+  bool is_uncommon_trap() const;
   static int extract_uncommon_trap_request(const Node* call);
 
   bool is_boxing_method() const {

--- a/src/hotspot/share/opto/classes.hpp
+++ b/src/hotspot/share/opto/classes.hpp
@@ -312,6 +312,7 @@ macro(RotateRight)
 macro(RotateRightV)
 macro(SafePoint)
 macro(SafePointScalarObject)
+macro(SafePointScalarMerge)
 #if INCLUDE_SHENANDOAHGC
 #define shmacro(x) macro(x)
 #else

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -519,6 +519,12 @@ void Compile::print_compile_messages() {
     tty->print_cr("** Bailout: Recompile without iterative escape analysis**");
     tty->print_cr("*********************************************************");
   }
+  if (do_reduce_allocation_merges() != ReduceAllocationMerges && PrintOpto) {
+    // Recompiling without reducing allocation merges
+    tty->print_cr("*********************************************************");
+    tty->print_cr("** Bailout: Recompile without reduce allocation merges **");
+    tty->print_cr("*********************************************************");
+  }
   if ((eliminate_boxing() != EliminateAutoBox) && PrintOpto) {
     // Recompiling without boxing elimination
     tty->print_cr("*********************************************************");
@@ -2290,10 +2296,10 @@ void Compile::Optimize() {
       // Cleanup graph (remove dead nodes).
       TracePhase tp("idealLoop", &timers[_t_idealLoop]);
       PhaseIdealLoop::optimize(igvn, LoopOptsMaxUnroll);
-      if (major_progress()) print_method(PHASE_PHASEIDEAL_BEFORE_EA, 2);
       if (failing())  return;
     }
     bool progress;
+    print_method(PHASE_PHASEIDEAL_BEFORE_EA, 2);
     do {
       ConnectionGraph::do_analysis(this, &igvn);
 
@@ -2311,13 +2317,16 @@ void Compile::Optimize() {
         TracePhase tp("macroEliminate", &timers[_t_macroEliminate]);
         PhaseMacroExpand mexp(igvn);
         mexp.eliminate_macro_nodes();
-        igvn.set_delay_transform(false);
+        if (failing()) return;
 
+        igvn.set_delay_transform(false);
         igvn.optimize();
         print_method(PHASE_ITER_GVN_AFTER_ELIMINATION, 2);
-
-        if (failing())  return;
       }
+
+      ConnectionGraph::verify_ram_nodes(this, root());
+      if (failing())  return;
+
       progress = do_iterative_escape_analysis() &&
                  (macro_count() < mcount) &&
                  ConnectionGraph::has_candidates(this);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -176,17 +176,20 @@ class Options {
   const bool _subsume_loads;         // Load can be matched as part of a larger op.
   const bool _do_escape_analysis;    // Do escape analysis.
   const bool _do_iterative_escape_analysis;  // Do iterative escape analysis.
+  const bool _do_reduce_allocation_merges;  // Do try to reduce allocation merges.
   const bool _eliminate_boxing;      // Do boxing elimination.
   const bool _do_locks_coarsening;   // Do locks coarsening
   const bool _install_code;          // Install the code that was compiled
  public:
   Options(bool subsume_loads, bool do_escape_analysis,
           bool do_iterative_escape_analysis,
+          bool do_reduce_allocation_merges,
           bool eliminate_boxing, bool do_locks_coarsening,
           bool install_code) :
           _subsume_loads(subsume_loads),
           _do_escape_analysis(do_escape_analysis),
           _do_iterative_escape_analysis(do_iterative_escape_analysis),
+          _do_reduce_allocation_merges(do_reduce_allocation_merges),
           _eliminate_boxing(eliminate_boxing),
           _do_locks_coarsening(do_locks_coarsening),
           _install_code(install_code) {
@@ -197,6 +200,7 @@ class Options {
        /* subsume_loads = */ true,
        /* do_escape_analysis = */ false,
        /* do_iterative_escape_analysis = */ false,
+       /* do_reduce_allocation_merges = */ false,
        /* eliminate_boxing = */ false,
        /* do_lock_coarsening = */ false,
        /* install_code = */ true
@@ -552,6 +556,7 @@ class Compile : public Phase {
   /** Do escape analysis. */
   bool              do_escape_analysis() const  { return _options._do_escape_analysis; }
   bool              do_iterative_escape_analysis() const  { return _options._do_iterative_escape_analysis; }
+  bool              do_reduce_allocation_merges() const  { return _options._do_reduce_allocation_merges; }
   /** Do boxing elimination. */
   bool              eliminate_boxing() const    { return _options._eliminate_boxing; }
   /** Do aggressive boxing elimination. */

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -36,13 +36,19 @@
 #include "opto/cfgnode.hpp"
 #include "opto/compile.hpp"
 #include "opto/escape.hpp"
+#include "opto/macro.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/movenode.hpp"
 #include "opto/rootnode.hpp"
 #include "utilities/macros.hpp"
 
 ConnectionGraph::ConnectionGraph(Compile * C, PhaseIterGVN *igvn, int invocation) :
-  _nodes(C->comp_arena(), C->unique(), C->unique(), nullptr),
+  // If ReduceAllocationMerges is enabled we might call split_through_phi during
+  // split_unique_types and that will create additional nodes that need to be
+  // pushed to the ConnectionGraph. The code below bumps the initial capacity of
+  // _nodes by 10% to account for these additional nodes. If capacity is exceeded
+  // the array will be reallocated.
+  _nodes(C->comp_arena(), C->do_reduce_allocation_merges() ? C->unique()*1.10 : C->unique(), C->unique(), nullptr),
   _in_worklist(C->comp_arena()),
   _next_pidx(0),
   _collecting(true),
@@ -56,11 +62,13 @@ ConnectionGraph::ConnectionGraph(Compile * C, PhaseIterGVN *igvn, int invocation
   // Add unknown java object.
   add_java_object(C->top(), PointsToNode::GlobalEscape);
   phantom_obj = ptnode_adr(C->top()->_idx)->as_JavaObject();
+  set_not_scalar_replaceable(phantom_obj NOT_PRODUCT(COMMA "Phantom object"));
   // Add ConP and ConN null oop nodes
   Node* oop_null = igvn->zerocon(T_OBJECT);
   assert(oop_null->_idx < nodes_size(), "should be created already");
   add_java_object(oop_null, PointsToNode::NoEscape);
   null_obj = ptnode_adr(oop_null->_idx)->as_JavaObject();
+  set_not_scalar_replaceable(null_obj NOT_PRODUCT(COMMA "Null object"));
   if (UseCompressedOops) {
     Node* noop_null = igvn->zerocon(T_NARROWOOP);
     assert(noop_null->_idx < nodes_size(), "should be created already");
@@ -124,6 +132,7 @@ bool ConnectionGraph::compute_escape() {
 
   // Worklists used by EA.
   Unique_Node_List delayed_worklist;
+  Unique_Node_List reducible_merges;
   GrowableArray<Node*> alloc_worklist;
   GrowableArray<Node*> ptr_cmp_worklist;
   GrowableArray<MemBarStoreStoreNode*> storestore_worklist;
@@ -292,7 +301,7 @@ bool ConnectionGraph::compute_escape() {
       n->as_Allocate()->_is_non_escaping = noescape;
     }
     if (noescape && ptn->scalar_replaceable()) {
-      adjust_scalar_replaceable_state(ptn);
+      adjust_scalar_replaceable_state(ptn, reducible_merges);
       if (ptn->scalar_replaceable()) {
         jobj_worklist.push(ptn);
       } else {
@@ -304,6 +313,15 @@ bool ConnectionGraph::compute_escape() {
   // Propagate NSR (Not Scalar Replaceable) state.
   if (found_nsr_alloc) {
     find_scalar_replaceable_allocs(jobj_worklist);
+  }
+
+  // alloc_worklist will be processed in reverse push order.
+  // Therefore the reducible Phis will be processed for last and that's what we
+  // want because by then the scalarizable inputs of the merge will already have
+  // an unique instance type.
+  for (uint i = 0; i < reducible_merges.size(); i++ ) {
+    Node* n = reducible_merges.at(i);
+    alloc_worklist.append(n);
   }
 
   for (int next = 0; next < jobj_worklist.length(); ++next) {
@@ -359,7 +377,7 @@ bool ConnectionGraph::compute_escape() {
     assert(C->do_aliasing(), "Aliasing should be enabled");
     // Now use the escape information to create unique types for
     // scalar replaceable objects.
-    split_unique_types(alloc_worklist, arraycopy_worklist, mergemem_worklist);
+    split_unique_types(alloc_worklist, arraycopy_worklist, mergemem_worklist, reducible_merges);
     if (C->failing()) {
       NOT_PRODUCT(escape_state_statistics(java_objects_worklist);)
       return false;
@@ -377,6 +395,21 @@ bool ConnectionGraph::compute_escape() {
     }
     tty->cr();
 #endif
+  }
+
+  // 6. Remove reducible allocation merges from ideal graph
+  if (reducible_merges.size() > 0) {
+    bool delay = _igvn->delay_transform();
+    _igvn->set_delay_transform(true);
+    for (uint i = 0; i < reducible_merges.size(); i++ ) {
+      Node* n = reducible_merges.at(i);
+      reduce_phi(n->as_Phi());
+      if (C->failing()) {
+        NOT_PRODUCT(escape_state_statistics(java_objects_worklist);)
+        return false;
+      }
+    }
+    _igvn->set_delay_transform(delay);
   }
 
   // Annotate at safepoints if they have <= ArgEscape objects in their scope and at
@@ -399,6 +432,352 @@ bool ConnectionGraph::compute_escape() {
 
   NOT_PRODUCT(escape_state_statistics(java_objects_worklist);)
   return has_non_escaping_obj;
+}
+
+// Check if it's profitable to reduce the Phi passed as parameter.  Returns true
+// if at least one scalar replaceable allocation participates in the merge and
+// no input to the Phi is nullable.
+bool ConnectionGraph::can_reduce_phi_check_inputs(PhiNode* ophi) const {
+  // Check if there is a scalar replaceable allocate in the Phi
+  bool found_sr_allocate = false;
+
+  for (uint i = 1; i < ophi->req(); i++) {
+    // Right now we can't restore a "null" pointer during deoptimization
+    const Type* inp_t = _igvn->type(ophi->in(i));
+    if (inp_t == nullptr || inp_t->make_oopptr() == nullptr || inp_t->make_oopptr()->maybe_null()) {
+      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Input %d is nullable.", ophi->_idx, _invocation, i);)
+      return false;
+    }
+
+    // We are looking for at least one SR object in the merge
+    JavaObjectNode* ptn = unique_java_object(ophi->in(i));
+    if (ptn != nullptr && ptn->scalar_replaceable()) {
+      assert(ptn->ideal_node() != nullptr && ptn->ideal_node()->is_Allocate(), "sanity");
+      AllocateNode* alloc = ptn->ideal_node()->as_Allocate();
+
+      if (PhaseMacroExpand::can_eliminate_allocation(_igvn, alloc, nullptr)) {
+        found_sr_allocate = true;
+      } else {
+        ptn->set_scalar_replaceable(false);
+      }
+    }
+  }
+
+  NOT_PRODUCT(if (TraceReduceAllocationMerges && !found_sr_allocate) tty->print_cr("Can NOT reduce Phi %d on invocation %d. No SR Allocate as input.", ophi->_idx, _invocation);)
+  return found_sr_allocate;
+}
+
+// Check if we are able to untangle the merge. Right now we only reduce Phis
+// which are only used as debug information.
+bool ConnectionGraph::can_reduce_phi_check_users(PhiNode* ophi) const {
+  for (DUIterator_Fast imax, i = ophi->fast_outs(imax); i < imax; i++) {
+    Node* use = ophi->fast_out(i);
+
+    if (use->is_SafePoint()) {
+      if (use->is_Call() && use->as_Call()->has_non_debug_use(ophi)) {
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Call has non_debug_use().", ophi->_idx, _invocation);)
+        return false;
+      }
+    } else if (use->is_AddP()) {
+      Node* addp = use;
+      for (DUIterator_Fast jmax, j = addp->fast_outs(jmax); j < jmax; j++) {
+        Node* use_use = addp->fast_out(j);
+        if (!use_use->is_Load() || !use_use->as_Load()->can_split_through_phi_base(_igvn)) {
+          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. AddP user isn't a [splittable] Load(): %s", ophi->_idx, _invocation, use_use->Name());)
+          return false;
+        }
+      }
+    } else {
+      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. One of the uses is: %d %s", ophi->_idx, _invocation, use->_idx, use->Name());)
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Returns true if: 1) It's profitable to reduce the merge, and 2) The Phi is
+// only used in some certain code shapes. Check comments in
+// 'can_reduce_phi_inputs' and 'can_reduce_phi_users' for more
+// details.
+bool ConnectionGraph::can_reduce_phi(PhiNode* ophi) const {
+  // If there was an error attempting to reduce allocation merges for this
+  // method we might have disabled the compilation and be retrying with RAM
+  // disabled.
+  // If EliminateAllocations is False, there is no point in reducing merges.
+  if (!_compile->do_reduce_allocation_merges()) {
+    return false;
+  }
+
+  const Type* phi_t = _igvn->type(ophi);
+  if (phi_t == nullptr || phi_t->make_ptr() == nullptr ||
+                          phi_t->make_ptr()->isa_instptr() == nullptr ||
+                          !phi_t->make_ptr()->isa_instptr()->klass_is_exact()) {
+    NOT_PRODUCT(if (TraceReduceAllocationMerges) { tty->print_cr("Can NOT reduce Phi %d during invocation %d because it's nullable.", ophi->_idx, _invocation); })
+    return false;
+  }
+
+  if (!can_reduce_phi_check_inputs(ophi) || !can_reduce_phi_check_users(ophi)) {
+    return false;
+  }
+
+  NOT_PRODUCT(if (TraceReduceAllocationMerges) { tty->print_cr("Can reduce Phi %d during invocation %d: ", ophi->_idx, _invocation); })
+  return true;
+}
+
+void ConnectionGraph::reduce_phi_on_field_access(PhiNode* ophi, GrowableArray<Node *>  &alloc_worklist) {
+  // We'll pass this to 'split_through_phi' so that it'll do the split even
+  // though the load doesn't have an unique instance type.
+  bool ignore_missing_instance_id = true;
+
+  // Iterate over Phi outputs looking for an AddP
+  for (int j = ophi->outcnt()-1; j >= 0;) {
+    Node* previous_addp = ophi->raw_out(j);
+    uint num_edges = 1;
+    if (previous_addp->is_AddP()) {
+      // All AddPs are present in the connection graph
+      FieldNode* fn = ptnode_adr(previous_addp->_idx)->as_Field();
+      num_edges = previous_addp->in(AddPNode::Address) == previous_addp->in(AddPNode::Base) ? 2 : 1;
+
+      // Iterate over AddP looking for a Load
+      for (int k = previous_addp->outcnt()-1; k >= 0;) {
+        Node* previous_load = previous_addp->raw_out(k);
+        if (previous_load->is_Load()) {
+          Node* data_phi = previous_load->as_Load()->split_through_phi(_igvn, ignore_missing_instance_id);
+          _igvn->replace_node(previous_load, data_phi);
+          assert(data_phi != nullptr, "Output of split_through_phi is null.");
+          assert(data_phi != previous_load, "Output of split_through_phi is same as input.");
+
+          // Push the newly created AddP on alloc_worklist and patch
+          // the connection graph. Note that the changes in the CG below
+          // won't affect the ES of objects since the new nodes have the
+          // same status as the old ones.
+          if (data_phi != nullptr && data_phi->is_Phi()) {
+            for (uint i = 1; i < data_phi->req(); i++) {
+              Node* new_load = data_phi->in(i);
+              if (new_load->is_Load()) {
+                Node* new_addp = new_load->in(MemNode::Address);
+                Node* base = get_addp_base(new_addp);
+
+                // The base might not be something that we can create an unique
+                // type for. If that's the case we are done with that input.
+                PointsToNode* jobj_ptn = unique_java_object(base);
+                if (jobj_ptn == nullptr || !jobj_ptn->scalar_replaceable()) {
+                  continue;
+                }
+
+                // Push to alloc_worklist since the base has an unique_type
+                alloc_worklist.append_if_missing(new_addp);
+
+                // Now let's add the node to the connection graph
+                _nodes.at_grow(new_addp->_idx, nullptr);
+                add_field(new_addp, fn->escape_state(), fn->offset());
+                add_base(ptnode_adr(new_addp->_idx)->as_Field(), ptnode_adr(base->_idx));
+
+                // If the load doesn't load an object then it won't be
+                // part of the connection graph
+                PointsToNode* curr_load_ptn = ptnode_adr(previous_load->_idx);
+                if (curr_load_ptn != nullptr) {
+                  _nodes.at_grow(new_load->_idx, nullptr);
+                  add_local_var(new_load, curr_load_ptn->escape_state());
+                  add_edge(ptnode_adr(new_load->_idx), ptnode_adr(new_addp->_idx)->as_Field());
+                }
+              }
+            }
+          }
+        }
+        --k;
+        k = MIN2(k, (int)previous_addp->outcnt()-1);
+      }
+
+      // Remove the old AddP from the processing list because it's dead now
+      alloc_worklist.remove_if_existing(previous_addp);
+    }
+    j -= num_edges;
+    j = MIN2(j, (int)ophi->outcnt()-1);
+  }
+}
+
+// This method will create a SafePointScalarObjectNode for each combination of
+// scalar replaceable allocation in 'ophi' and SafePoint node in 'safepoints'.
+// The method will create a SafePointScalarMERGEnode for each combination of
+// 'ophi' and SafePoint node in 'safepoints'.
+// Each SafePointScalarMergeNode created here may describe multiple scalar
+// replaced objects - check detailed description in SafePointScalarMergeNode
+// class header.
+//
+// This method will set entries in the Phi that are scalar replaceable to 'null'.
+void ConnectionGraph::reduce_phi_on_safepoints(PhiNode* ophi, Unique_Node_List* safepoints) {
+  Node* minus_one           = _igvn->register_new_node_with_optimizer(ConINode::make(-1));
+  Node* selector            = _igvn->register_new_node_with_optimizer(PhiNode::make(ophi->region(), minus_one, TypeInt::INT));
+  Node* null_ptr            = _igvn->makecon(TypePtr::NULL_PTR);
+  const TypeOopPtr* merge_t = _igvn->type(ophi)->make_oopptr();
+  uint number_of_sr_objects = 0;
+  PhaseMacroExpand mexp(*_igvn);
+
+  _igvn->hash_delete(ophi);
+
+  // Fill in the 'selector' Phi. If index 'i' of the selector is:
+  // -> a '-1' constant, the i'th input of the original Phi is NSR.
+  // -> a 'x' constant >=0, the i'th input of of original Phi will be SR and the
+  //    info about the scalarized object will be at index x of
+  //    ObjectMergeValue::possible_objects
+  for (uint i = 1; i < ophi->req(); i++) {
+    Node* base          = ophi->in(i);
+    JavaObjectNode* ptn = unique_java_object(base);
+
+    if (ptn != nullptr && ptn->scalar_replaceable()) {
+      Node* sr_obj_idx = _igvn->register_new_node_with_optimizer(ConINode::make(number_of_sr_objects));
+      selector->set_req(i, sr_obj_idx);
+      number_of_sr_objects++;
+    }
+  }
+
+  // Update the debug information of all safepoints in turn
+  for (uint spi = 0; spi < safepoints->size(); spi++) {
+    SafePointNode* sfpt = safepoints->at(spi)->as_SafePoint();
+    JVMState *jvms      = sfpt->jvms();
+    uint merge_idx      = (sfpt->req() - jvms->scloff());
+    int debug_start     = jvms->debug_start();
+
+    SafePointScalarMergeNode* smerge = new SafePointScalarMergeNode(merge_t, merge_idx);
+    smerge->init_req(0, _compile->root());
+    _igvn->register_new_node_with_optimizer(smerge);
+
+    // The next two inputs are:
+    //  (1) A copy of the original pointer to NSR objects.
+    //  (2) A selector, used to decide if we need to rematerialize an object
+    //      or use the pointer to a NSR object.
+    // See more details of these fields in the declaration of SafePointScalarMergeNode
+    sfpt->add_req(ophi);
+    sfpt->add_req(selector);
+
+    for (uint i = 1; i < ophi->req(); i++) {
+      Node* base          = ophi->in(i);
+      JavaObjectNode* ptn = unique_java_object(base);
+
+      // If the base is not scalar replaceable we don't need to register information about
+      // it at this time.
+      if (ptn == nullptr || !ptn->scalar_replaceable()) {
+        continue;
+      }
+
+      AllocateNode* alloc = ptn->ideal_node()->as_Allocate();
+      SafePointScalarObjectNode* sobj = mexp.create_scalarized_object_description(alloc, sfpt);
+      if (sobj == nullptr) {
+        _compile->record_failure(C2Compiler::retry_no_reduce_allocation_merges());
+        return;
+      }
+
+      // Now make a pass over the debug information replacing any references
+      // to the allocated object with "sobj"
+      Node* ccpp = alloc->result_cast();
+      sfpt->replace_edges_in_range(ccpp, sobj, debug_start, jvms->debug_end(), _igvn);
+
+      // Register the scalarized object as a candidate for reallocation
+      smerge->add_req(sobj);
+    }
+
+    // Replaces debug information references to "ophi" in "sfpt" with references to "smerge"
+    sfpt->replace_edges_in_range(ophi, smerge, debug_start, jvms->debug_end(), _igvn);
+
+    // The call to 'replace_edges_in_range' above might have removed the
+    // reference to ophi that we need at _merge_pointer_idx. The line below make
+    // sure the reference is maintained.
+    sfpt->set_req(smerge->merge_pointer_idx(jvms), ophi);
+    _igvn->_worklist.push(sfpt);
+  }
+
+  // Now we can change ophi since we don't need to know the types
+  // of the input allocations anymore.
+  const Type* new_t = merge_t->meet(TypePtr::NULL_PTR);
+  Node* new_phi = _igvn->register_new_node_with_optimizer(PhiNode::make(ophi->region(), null_ptr, new_t));
+  for (uint i = 1; i < ophi->req(); i++) {
+    Node* base          = ophi->in(i);
+    JavaObjectNode* ptn = unique_java_object(base);
+
+    if (ptn != nullptr && ptn->scalar_replaceable()) {
+      new_phi->set_req(i, null_ptr);
+    } else {
+      new_phi->set_req(i, ophi->in(i));
+    }
+  }
+
+  _igvn->replace_node(ophi, new_phi);
+  _igvn->hash_insert(ophi);
+  _igvn->_worklist.push(ophi);
+}
+
+void ConnectionGraph::reduce_phi(PhiNode* ophi) {
+  Unique_Node_List safepoints;
+
+  for (uint i = 0; i < ophi->outcnt(); i++) {
+    Node* use = ophi->raw_out(i);
+
+    // All SafePoint nodes using the same Phi node use the same debug
+    // information (regarding the Phi). Furthermore, reducing the Phi used by a
+    // SafePoint requires changing the Phi. Therefore, I collect all safepoints
+    // and patch them all at once later.
+    if (use->is_SafePoint()) {
+      safepoints.push(use->as_SafePoint());
+    } else {
+#ifdef ASSERT
+      ophi->dump(-3);
+      assert(false, "Unexpected user of reducible Phi %d -> %d:%s", ophi->_idx, use->_idx, use->Name());
+#endif
+      _compile->record_failure(C2Compiler::retry_no_reduce_allocation_merges());
+      return;
+    }
+  }
+
+  if (safepoints.size() > 0) {
+    reduce_phi_on_safepoints(ophi, &safepoints);
+  }
+}
+
+void ConnectionGraph::verify_ram_nodes(Compile* C, Node* root) {
+  if (!C->do_reduce_allocation_merges()) return;
+
+  Unique_Node_List ideal_nodes;
+  ideal_nodes.map(C->live_nodes(), nullptr);  // preallocate space
+  ideal_nodes.push(root);
+
+  for (uint next = 0; next < ideal_nodes.size(); ++next) {
+    Node* n = ideal_nodes.at(next);
+
+    if (n->is_SafePointScalarMerge()) {
+      SafePointScalarMergeNode* merge = n->as_SafePointScalarMerge();
+
+      // Validate inputs of merge
+      for (uint i = 1; i < merge->req(); i++) {
+        if (merge->in(i) != nullptr && !merge->in(i)->is_top() && !merge->in(i)->is_SafePointScalarObject()) {
+          assert(false, "SafePointScalarMerge inputs should be null/top or SafePointScalarObject.");
+          C->record_failure(C2Compiler::retry_no_reduce_allocation_merges());
+        }
+      }
+
+      // Validate users of merge
+      for (DUIterator_Fast imax, i = merge->fast_outs(imax); i < imax; i++) {
+        Node* sfpt = merge->fast_out(i);
+        if (sfpt->is_SafePoint()) {
+          int merge_idx = merge->merge_pointer_idx(sfpt->as_SafePoint()->jvms());
+
+          if (sfpt->in(merge_idx) != nullptr && sfpt->in(merge_idx)->is_SafePointScalarMerge()) {
+            assert(false, "SafePointScalarMerge nodes can't be nested.");
+            C->record_failure(C2Compiler::retry_no_reduce_allocation_merges());
+          }
+        } else {
+          assert(false, "Only safepoints can use SafePointScalarMerge nodes.");
+          C->record_failure(C2Compiler::retry_no_reduce_allocation_merges());
+        }
+      }
+    }
+
+    for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+      Node* m = n->fast_out(i);
+      ideal_nodes.push(m);
+    }
+  }
 }
 
 // Returns true if there is an object in the scope of sfn that does not escape globally.
@@ -580,7 +959,8 @@ void ConnectionGraph::add_node_to_connection_graph(Node *n, Unique_Node_List *de
       } else {
         es = PointsToNode::GlobalEscape;
       }
-      add_java_object(n, es);
+      PointsToNode* ptn_con = add_java_object(n, es);
+      set_not_scalar_replaceable(ptn_con NOT_PRODUCT(COMMA "Constant pointer"));
       break;
     }
     case Op_CreateEx: {
@@ -670,7 +1050,8 @@ void ConnectionGraph::add_node_to_connection_graph(Node *n, Unique_Node_List *de
       break;
     }
     case Op_ThreadLocal: {
-      add_java_object(n, PointsToNode::ArgEscape);
+      PointsToNode* ptn_thr = add_java_object(n, PointsToNode::ArgEscape);
+      set_not_scalar_replaceable(ptn_thr NOT_PRODUCT(COMMA "Constant pointer"));
       break;
     }
     case Op_Blackhole: {
@@ -1048,6 +1429,9 @@ void ConnectionGraph::add_call_node(CallNode* call) {
         es = PointsToNode::GlobalEscape;
       }
       add_java_object(call, es);
+      if (es == PointsToNode::GlobalEscape) {
+        set_not_scalar_replaceable(ptnode_adr(call->_idx) NOT_PRODUCT(COMMA "object can be loaded from boxing cache"));
+      }
     } else {
       BCEscapeAnalyzer* call_analyzer = meth->get_bcea();
       call_analyzer->copy_dependencies(_compile->dependencies());
@@ -1861,7 +2245,15 @@ int ConnectionGraph::find_init_values_null(JavaObjectNode* pta, PhaseValues* pha
 }
 
 // Adjust scalar_replaceable state after Connection Graph is built.
-void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
+void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj, Unique_Node_List &reducible_merges) {
+  // A Phi 'x' is a _candidate_ to be reducible if 'can_reduce_phi(x)'
+  // returns true. If one of the constraints in this method set 'jobj' to NSR
+  // then the candidate Phi is discarded. If the Phi has another SR 'jobj' as
+  // input, 'adjust_scalar_replaceable_state' will eventually be called with
+  // that other object and the Phi will become a reducible Phi.
+  // There could be multiple merges involving the same jobj.
+  Unique_Node_List candidates;
+
   // Search for non-escaping objects which are not scalar replaceable
   // and mark them to propagate the state to referenced objects.
 
@@ -1896,13 +2288,28 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
       }
     }
     assert(use->is_Field() || use->is_LocalVar(), "sanity");
-    // 3. An object is not scalar replaceable if it is merged with other objects.
+    // 3. An object is not scalar replaceable if it is merged with other objects
+    // and we can't remove the merge
     for (EdgeIterator j(use); j.has_next(); j.next()) {
       PointsToNode* ptn = j.get();
       if (ptn->is_JavaObject() && ptn != jobj) {
-        // Mark all objects.
-        set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA trace_merged_message(ptn)));
-        set_not_scalar_replaceable(ptn NOT_PRODUCT(COMMA trace_merged_message(jobj)));
+        Node* use_n = use->ideal_node();
+
+        // If it's already a candidate or confirmed reducible merge we can skip verification
+        if (candidates.member(use_n)) {
+          continue;
+        } else if (reducible_merges.member(use_n)) {
+          candidates.push(use_n);
+          continue;
+        }
+
+        if (use_n->is_Phi() && can_reduce_phi(use_n->as_Phi())) {
+          candidates.push(use_n);
+        } else {
+          // Mark all objects as NSR if we can't remove the merge
+          set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA trace_merged_message(ptn)));
+          set_not_scalar_replaceable(ptn NOT_PRODUCT(COMMA trace_merged_message(jobj)));
+        }
       }
     }
     if (!jobj->scalar_replaceable()) {
@@ -1965,7 +2372,7 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
     //    Point p[] = new Point[1];
     //    if ( x ) p[0] = new Point(); // Will be not scalar replaced
     //
-    if (field->base_count() > 1) {
+    if (field->base_count() > 1 && candidates.size() == 0) {
       for (BaseIterator i(field); i.has_next(); i.next()) {
         PointsToNode* base = i.get();
         // Don't take into account LocalVar nodes which
@@ -1977,7 +2384,20 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
           set_not_scalar_replaceable(base NOT_PRODUCT(COMMA "may point to more than one object"));
         }
       }
+
+      if (!jobj->scalar_replaceable()) {
+        return;
+      }
     }
+  }
+
+  // The candidate is truly a reducible merge only if none of the other
+  // constraints ruled it as NSR. There could be multiple merges involving the
+  // same jobj.
+  assert(jobj->scalar_replaceable(), "sanity");
+  for (uint i = 0; i < candidates.size(); i++ ) {
+    Node* candidate = candidates.at(i);
+    reducible_merges.push(candidate);
   }
 }
 
@@ -2244,15 +2664,16 @@ void ConnectionGraph::add_local_var(Node *n, PointsToNode::EscapeState es) {
   map_ideal_node(n, ptadr);
 }
 
-void ConnectionGraph::add_java_object(Node *n, PointsToNode::EscapeState es) {
+PointsToNode* ConnectionGraph::add_java_object(Node *n, PointsToNode::EscapeState es) {
   PointsToNode* ptadr = _nodes.at(n->_idx);
   if (ptadr != nullptr) {
     assert(ptadr->is_JavaObject() && ptadr->ideal_node() == n, "sanity");
-    return;
+    return ptadr;
   }
   Compile* C = _compile;
   ptadr = new (C->comp_arena()) JavaObjectNode(this, n, es);
   map_ideal_node(n, ptadr);
+  return ptadr;
 }
 
 void ConnectionGraph::add_field(Node *n, PointsToNode::EscapeState es, int offset) {
@@ -2343,8 +2764,7 @@ bool ConnectionGraph::is_oop_field(Node* n, int offset, bool* unsafe) {
 }
 
 // Returns unique pointed java object or null.
-JavaObjectNode* ConnectionGraph::unique_java_object(Node *n) {
-  assert(!_collecting, "should not call when constructed graph");
+JavaObjectNode* ConnectionGraph::unique_java_object(Node *n) const {
   // If the node was created after the escape computation we can't answer.
   uint idx = n->_idx;
   if (idx >= nodes_size()) {
@@ -3183,7 +3603,8 @@ Node* ConnectionGraph::find_inst_mem(Node *orig_mem, int alias_idx, GrowableArra
 //
 void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
                                          GrowableArray<ArrayCopyNode*> &arraycopy_worklist,
-                                         GrowableArray<MergeMemNode*> &mergemem_worklist) {
+                                         GrowableArray<MergeMemNode*> &mergemem_worklist,
+                                         Unique_Node_List &reducible_merges) {
   GrowableArray<Node *>  memnode_worklist;
   GrowableArray<PhiNode *>  orig_phis;
   PhaseIterGVN  *igvn = _igvn;
@@ -3330,7 +3751,12 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         }
       }
     } else if (n->is_AddP()) {
-      JavaObjectNode* jobj = unique_java_object(get_addp_base(n));
+      Node* addp_base = get_addp_base(n);
+      if (addp_base != nullptr && reducible_merges.member(addp_base)) {
+        // This AddP will go away when we reduce the the Phi
+        continue;
+      }
+      JavaObjectNode* jobj = unique_java_object(addp_base);
       if (jobj == nullptr || jobj == phantom_obj) {
 #ifdef ASSERT
         ptnode_adr(get_addp_base(n)->_idx)->dump();
@@ -3350,6 +3776,12 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       if (visited.test_set(n->_idx)) {
         assert(n->is_Phi(), "loops only through Phi's");
         continue;  // already processed
+      }
+      // Reducible Phi's will be removed from the graph after split_unique_types finishes
+      if (reducible_merges.member(n)) {
+        // Split loads through phi
+        reduce_phi_on_field_access(n->as_Phi(), alloc_worklist);
+        continue;
       }
       JavaObjectNode* jobj = unique_java_object(n);
       if (jobj == nullptr || jobj == phantom_obj) {
@@ -3460,6 +3892,20 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
 
   }
 
+#ifdef ASSERT
+  // At this point reducible Phis shouldn't have AddP users anymore; only SafePoints.
+  for (uint i = 0; i < reducible_merges.size(); i++) {
+    Node* phi = reducible_merges.at(i);
+    for (DUIterator_Fast jmax, j = phi->fast_outs(jmax); j < jmax; j++) {
+      Node* use = phi->fast_out(j);
+      if (!use->is_SafePoint()) {
+        phi->dump(-3);
+        assert(false, "Unexpected user of reducible Phi -> %s", use->Name());
+      }
+    }
+  }
+#endif
+
   // Go over all ArrayCopy nodes and if one of the inputs has a unique
   // type, record it in the ArrayCopy node so we know what memory this
   // node uses/modified.
@@ -3493,7 +3939,6 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
 
   // New alias types were created in split_AddP().
   uint new_index_end = (uint) _compile->num_alias_types();
-  assert(unique_old == _compile->unique(), "there should be no new ideal nodes after Phase 1");
 
   //  Phase 2:  Process MemNode's from memnode_worklist. compute new address type and
   //            compute new values for Memory inputs  (the Memory inputs are not

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -550,12 +550,13 @@ Node *PhaseMacroExpand::value_from_mem(Node *sfpt_mem, Node *sfpt_ctl, BasicType
 }
 
 // Check the possibility of scalar replacement.
-bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints) {
+bool PhaseMacroExpand::can_eliminate_allocation(PhaseIterGVN* igvn, AllocateNode *alloc, GrowableArray <SafePointNode *>* safepoints) {
   //  Scan the uses of the allocation to check for anything that would
   //  prevent us from eliminating it.
   NOT_PRODUCT( const char* fail_eliminate = nullptr; )
   DEBUG_ONLY( Node* disq_node = nullptr; )
-  bool  can_eliminate = true;
+  bool can_eliminate = true;
+  bool reduce_merge_precheck = (safepoints == nullptr);
 
   Node* res = alloc->result_cast();
   const TypeOopPtr* res_type = nullptr;
@@ -565,7 +566,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
     NOT_PRODUCT(fail_eliminate = "Allocation does not have unique CheckCastPP";)
     can_eliminate = false;
   } else {
-    res_type = _igvn.type(res)->isa_oopptr();
+    res_type = igvn->type(res)->isa_oopptr();
     if (res_type == nullptr) {
       NOT_PRODUCT(fail_eliminate = "Neither instance or array allocation";)
       can_eliminate = false;
@@ -585,7 +586,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
       Node* use = res->fast_out(j);
 
       if (use->is_AddP()) {
-        const TypePtr* addp_type = _igvn.type(use)->is_ptr();
+        const TypePtr* addp_type = igvn->type(use)->is_ptr();
         int offset = addp_type->offset();
 
         if (offset == Type::OffsetTop || offset == Type::OffsetBot) {
@@ -626,9 +627,11 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
           DEBUG_ONLY(disq_node = use;)
           NOT_PRODUCT(fail_eliminate = "null or TOP memory";)
           can_eliminate = false;
-        } else {
-          safepoints.append_if_missing(sfpt);
+        } else if (!reduce_merge_precheck) {
+          safepoints->append_if_missing(sfpt);
         }
+      } else if (reduce_merge_precheck && (use->is_Phi() || use->is_EncodeP() || use->Opcode() == Op_MemBarRelease)) {
+        // Nothing to do
       } else if (use->Opcode() != Op_CastP2X) { // CastP2X is used by card mark
         if (use->is_Phi()) {
           if (use->outcnt() == 1 && use->unique_out()->Opcode() == Op_Return) {
@@ -640,7 +643,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
         } else {
           if (use->Opcode() == Op_Return) {
             NOT_PRODUCT(fail_eliminate = "Object is return value";)
-          }else {
+          } else {
             NOT_PRODUCT(fail_eliminate = "Object is referenced by node";)
           }
           DEBUG_ONLY(disq_node = use;)
@@ -651,7 +654,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
   }
 
 #ifndef PRODUCT
-  if (PrintEliminateAllocations) {
+  if (PrintEliminateAllocations && safepoints != nullptr) {
     if (can_eliminate) {
       tty->print("Scalar ");
       if (res == nullptr)
@@ -676,25 +679,73 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
   return can_eliminate;
 }
 
-// Do scalar replacement.
-bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints) {
-  GrowableArray <SafePointNode *> safepoints_done;
-
-  ciInstanceKlass* iklass = nullptr;
-  int nfields = 0;
-  int array_base = 0;
-  int element_size = 0;
-  BasicType basic_elem_type = T_ILLEGAL;
-  const Type* field_type = nullptr;
-
+void PhaseMacroExpand::undo_previous_scalarizations(GrowableArray <SafePointNode *> safepoints_done, AllocateNode* alloc) {
   Node* res = alloc->result_cast();
+  int nfields = 0;
   assert(res == nullptr || res->is_CheckCastPP(), "unexpected AllocateNode result");
-  const TypeOopPtr* res_type = nullptr;
-  if (res != nullptr) { // Could be null when there are no users
-    res_type = _igvn.type(res)->isa_oopptr();
-  }
 
   if (res != nullptr) {
+    const TypeOopPtr* res_type = _igvn.type(res)->isa_oopptr();
+
+    if (res_type->isa_instptr()) {
+      // find the fields of the class which will be needed for safepoint debug information
+      ciInstanceKlass* iklass = res_type->is_instptr()->instance_klass();
+      nfields = iklass->nof_nonstatic_fields();
+    } else {
+      // find the array's elements which will be needed for safepoint debug information
+      nfields = alloc->in(AllocateNode::ALength)->find_int_con(-1);
+      assert(nfields >= 0, "must be an array klass.");
+    }
+  }
+
+  // rollback processed safepoints
+  while (safepoints_done.length() > 0) {
+    SafePointNode* sfpt_done = safepoints_done.pop();
+    // remove any extra entries we added to the safepoint
+    uint last = sfpt_done->req() - 1;
+    for (int k = 0;  k < nfields; k++) {
+      sfpt_done->del_req(last--);
+    }
+    JVMState *jvms = sfpt_done->jvms();
+    jvms->set_endoff(sfpt_done->req());
+    // Now make a pass over the debug information replacing any references
+    // to SafePointScalarObjectNode with the allocated object.
+    int start = jvms->debug_start();
+    int end   = jvms->debug_end();
+    for (int i = start; i < end; i++) {
+      if (sfpt_done->in(i)->is_SafePointScalarObject()) {
+        SafePointScalarObjectNode* scobj = sfpt_done->in(i)->as_SafePointScalarObject();
+        if (scobj->first_index(jvms) == sfpt_done->req() &&
+            scobj->n_fields() == (uint)nfields) {
+          assert(scobj->alloc() == alloc, "sanity");
+          sfpt_done->set_req(i, res);
+        }
+      }
+    }
+    _igvn._worklist.push(sfpt_done);
+  }
+}
+
+SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_description(AllocateNode *alloc, SafePointNode* sfpt) {
+  // Fields of scalar objs are referenced only at the end
+  // of regular debuginfo at the last (youngest) JVMS.
+  // Record relative start index.
+  ciInstanceKlass* iklass    = nullptr;
+  BasicType basic_elem_type  = T_ILLEGAL;
+  const Type* field_type     = nullptr;
+  const TypeOopPtr* res_type = nullptr;
+  int nfields                = 0;
+  int array_base             = 0;
+  int element_size           = 0;
+  uint first_ind             = (sfpt->req() - sfpt->jvms()->scloff());
+  Node* res                  = alloc->result_cast();
+
+  assert(res == nullptr || res->is_CheckCastPP(), "unexpected AllocateNode result");
+  assert(sfpt->jvms() != nullptr, "missed JVMS");
+
+  if (res != nullptr) { // Could be null when there are no users
+    res_type = _igvn.type(res)->isa_oopptr();
+
     if (res_type->isa_instptr()) {
       // find the fields of the class which will be needed for safepoint debug information
       iklass = res_type->is_instptr()->instance_klass();
@@ -709,141 +760,122 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       field_type = res_type->is_aryptr()->elem();
     }
   }
-  //
-  // Process the safepoint uses
-  //
-  while (safepoints.length() > 0) {
-    SafePointNode* sfpt = safepoints.pop();
-    Node* mem = sfpt->memory();
-    Node* ctl = sfpt->control();
-    assert(sfpt->jvms() != nullptr, "missed JVMS");
-    // Fields of scalar objs are referenced only at the end
-    // of regular debuginfo at the last (youngest) JVMS.
-    // Record relative start index.
-    uint first_ind = (sfpt->req() - sfpt->jvms()->scloff());
-    SafePointScalarObjectNode* sobj = new SafePointScalarObjectNode(res_type,
-#ifdef ASSERT
-                                                 alloc,
-#endif
-                                                 first_ind, nfields);
-    sobj->init_req(0, C->root());
-    transform_later(sobj);
 
-    // Scan object's fields adding an input to the safepoint for each field.
-    for (int j = 0; j < nfields; j++) {
-      intptr_t offset;
-      ciField* field = nullptr;
-      if (iklass != nullptr) {
-        field = iklass->nonstatic_field_at(j);
-        offset = field->offset_in_bytes();
-        ciType* elem_type = field->type();
-        basic_elem_type = field->layout_type();
+  SafePointScalarObjectNode* sobj = new SafePointScalarObjectNode(res_type, alloc, first_ind, nfields);
+  sobj->init_req(0, C->root());
+  transform_later(sobj);
 
-        // The next code is taken from Parse::do_get_xxx().
-        if (is_reference_type(basic_elem_type)) {
-          if (!elem_type->is_loaded()) {
-            field_type = TypeInstPtr::BOTTOM;
-          } else if (field != nullptr && field->is_static_constant()) {
-            ciObject* con = field->constant_value().as_object();
-            // Do not "join" in the previous type; it doesn't add value,
-            // and may yield a vacuous result if the field is of interface type.
-            field_type = TypeOopPtr::make_from_constant(con)->isa_oopptr();
-            assert(field_type != nullptr, "field singleton type must be consistent");
-          } else {
-            field_type = TypeOopPtr::make_from_klass(elem_type->as_klass());
-          }
-          if (UseCompressedOops) {
-            field_type = field_type->make_narrowoop();
-            basic_elem_type = T_NARROWOOP;
-          }
+  // Scan object's fields adding an input to the safepoint for each field.
+  for (int j = 0; j < nfields; j++) {
+    intptr_t offset;
+    ciField* field = nullptr;
+    if (iklass != nullptr) {
+      field = iklass->nonstatic_field_at(j);
+      offset = field->offset_in_bytes();
+      ciType* elem_type = field->type();
+      basic_elem_type = field->layout_type();
+
+      // The next code is taken from Parse::do_get_xxx().
+      if (is_reference_type(basic_elem_type)) {
+        if (!elem_type->is_loaded()) {
+          field_type = TypeInstPtr::BOTTOM;
+        } else if (field != nullptr && field->is_static_constant()) {
+          ciObject* con = field->constant_value().as_object();
+          // Do not "join" in the previous type; it doesn't add value,
+          // and may yield a vacuous result if the field is of interface type.
+          field_type = TypeOopPtr::make_from_constant(con)->isa_oopptr();
+          assert(field_type != nullptr, "field singleton type must be consistent");
         } else {
-          field_type = Type::get_const_basic_type(basic_elem_type);
+          field_type = TypeOopPtr::make_from_klass(elem_type->as_klass());
+        }
+        if (UseCompressedOops) {
+          field_type = field_type->make_narrowoop();
+          basic_elem_type = T_NARROWOOP;
         }
       } else {
-        offset = array_base + j * (intptr_t)element_size;
+        field_type = Type::get_const_basic_type(basic_elem_type);
       }
-
-      const TypeOopPtr *field_addr_type = res_type->add_offset(offset)->isa_oopptr();
-
-      Node *field_val = value_from_mem(mem, ctl, basic_elem_type, field_type, field_addr_type, alloc);
-      if (field_val == nullptr) {
-        // We weren't able to find a value for this field,
-        // give up on eliminating this allocation.
-
-        // Remove any extra entries we added to the safepoint.
-        uint last = sfpt->req() - 1;
-        for (int k = 0;  k < j; k++) {
-          sfpt->del_req(last--);
-        }
-        _igvn._worklist.push(sfpt);
-        // rollback processed safepoints
-        while (safepoints_done.length() > 0) {
-          SafePointNode* sfpt_done = safepoints_done.pop();
-          // remove any extra entries we added to the safepoint
-          last = sfpt_done->req() - 1;
-          for (int k = 0;  k < nfields; k++) {
-            sfpt_done->del_req(last--);
-          }
-          JVMState *jvms = sfpt_done->jvms();
-          jvms->set_endoff(sfpt_done->req());
-          // Now make a pass over the debug information replacing any references
-          // to SafePointScalarObjectNode with the allocated object.
-          int start = jvms->debug_start();
-          int end   = jvms->debug_end();
-          for (int i = start; i < end; i++) {
-            if (sfpt_done->in(i)->is_SafePointScalarObject()) {
-              SafePointScalarObjectNode* scobj = sfpt_done->in(i)->as_SafePointScalarObject();
-              if (scobj->first_index(jvms) == sfpt_done->req() &&
-                  scobj->n_fields() == (uint)nfields) {
-                assert(scobj->alloc() == alloc, "sanity");
-                sfpt_done->set_req(i, res);
-              }
-            }
-          }
-          _igvn._worklist.push(sfpt_done);
-        }
-#ifndef PRODUCT
-        if (PrintEliminateAllocations) {
-          if (field != nullptr) {
-            tty->print("=== At SafePoint node %d can't find value of Field: ",
-                       sfpt->_idx);
-            field->print();
-            int field_idx = C->get_alias_index(field_addr_type);
-            tty->print(" (alias_idx=%d)", field_idx);
-          } else { // Array's element
-            tty->print("=== At SafePoint node %d can't find value of array element [%d]",
-                       sfpt->_idx, j);
-          }
-          tty->print(", which prevents elimination of: ");
-          if (res == nullptr)
-            alloc->dump();
-          else
-            res->dump();
-        }
-#endif
-        return false;
-      }
-      if (UseCompressedOops && field_type->isa_narrowoop()) {
-        // Enable "DecodeN(EncodeP(Allocate)) --> Allocate" transformation
-        // to be able scalar replace the allocation.
-        if (field_val->is_EncodeP()) {
-          field_val = field_val->in(1);
-        } else {
-          field_val = transform_later(new DecodeNNode(field_val, field_val->get_ptr_type()));
-        }
-      }
-      sfpt->add_req(field_val);
+    } else {
+      offset = array_base + j * (intptr_t)element_size;
     }
-    JVMState *jvms = sfpt->jvms();
-    jvms->set_endoff(sfpt->req());
+
+    const TypeOopPtr *field_addr_type = res_type->add_offset(offset)->isa_oopptr();
+
+    Node *field_val = value_from_mem(sfpt->memory(), sfpt->control(), basic_elem_type, field_type, field_addr_type, alloc);
+
+    // We weren't able to find a value for this field,
+    // give up on eliminating this allocation.
+    if (field_val == nullptr) {
+      uint last = sfpt->req() - 1;
+      for (int k = 0;  k < j; k++) {
+        sfpt->del_req(last--);
+      }
+      _igvn._worklist.push(sfpt);
+
+#ifndef PRODUCT
+      if (PrintEliminateAllocations) {
+        if (field != nullptr) {
+          tty->print("=== At SafePoint node %d can't find value of field: ", sfpt->_idx);
+          field->print();
+          int field_idx = C->get_alias_index(field_addr_type);
+          tty->print(" (alias_idx=%d)", field_idx);
+        } else { // Array's element
+          tty->print("=== At SafePoint node %d can't find value of array element [%d]", sfpt->_idx, j);
+        }
+        tty->print(", which prevents elimination of: ");
+        if (res == nullptr)
+          alloc->dump();
+        else
+          res->dump();
+      }
+#endif
+
+      return nullptr;
+    }
+
+    if (UseCompressedOops && field_type->isa_narrowoop()) {
+      // Enable "DecodeN(EncodeP(Allocate)) --> Allocate" transformation
+      // to be able scalar replace the allocation.
+      if (field_val->is_EncodeP()) {
+        field_val = field_val->in(1);
+      } else {
+        field_val = transform_later(new DecodeNNode(field_val, field_val->get_ptr_type()));
+      }
+    }
+    sfpt->add_req(field_val);
+  }
+
+  sfpt->jvms()->set_endoff(sfpt->req());
+
+  return sobj;
+}
+
+// Do scalar replacement.
+bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints) {
+  GrowableArray <SafePointNode *> safepoints_done;
+  Node* res = alloc->result_cast();
+  assert(res == nullptr || res->is_CheckCastPP(), "unexpected AllocateNode result");
+
+  // Process the safepoint uses
+  while (safepoints.length() > 0) {
+    SafePointNode* sfpt = safepoints.pop();
+    SafePointScalarObjectNode* sobj = create_scalarized_object_description(alloc, sfpt);
+
+    if (sobj == nullptr) {
+      undo_previous_scalarizations(safepoints_done, alloc);
+      return false;
+    }
+
     // Now make a pass over the debug information replacing any references
     // to the allocated object with "sobj"
-    int start = jvms->debug_start();
-    int end   = jvms->debug_end();
-    sfpt->replace_edges_in_range(res, sobj, start, end, &_igvn);
+    JVMState *jvms = sfpt->jvms();
+    sfpt->replace_edges_in_range(res, sobj, jvms->debug_start(), jvms->debug_end(), &_igvn);
     _igvn._worklist.push(sfpt);
-    safepoints_done.append_if_missing(sfpt); // keep it for rollback
+
+    // keep it for rollback
+    safepoints_done.append_if_missing(sfpt);
   }
+
   return true;
 }
 
@@ -1030,7 +1062,7 @@ bool PhaseMacroExpand::eliminate_allocate_node(AllocateNode *alloc) {
   alloc->extract_projections(&_callprojs, false /*separate_io_proj*/, false /*do_asserts*/);
 
   GrowableArray <SafePointNode *> safepoints;
-  if (!can_eliminate_allocation(alloc, safepoints)) {
+  if (!can_eliminate_allocation(&_igvn, alloc, &safepoints)) {
     return false;
   }
 

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -99,8 +99,8 @@ private:
 
   bool eliminate_boxing_node(CallStaticJavaNode *boxing);
   bool eliminate_allocate_node(AllocateNode *alloc);
-  bool can_eliminate_allocation(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints);
-  bool scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints_done);
+  void undo_previous_scalarizations(GrowableArray <SafePointNode *> safepoints_done, AllocateNode* alloc);
+  bool scalar_replacement(AllocateNode *alloc, GrowableArray <SafePointNode *>& safepoints);
   void process_users_of_allocation(CallNode *alloc);
 
   void eliminate_gc_barrier(Node *p2x);
@@ -204,6 +204,10 @@ public:
   }
   void eliminate_macro_nodes();
   bool expand_macro_nodes();
+
+  SafePointScalarObjectNode* create_scalarized_object_description(AllocateNode *alloc, SafePointNode* sfpt);
+  static bool can_eliminate_allocation(PhaseIterGVN *igvn, AllocateNode *alloc, GrowableArray <SafePointNode *> *safepoints);
+
 
   PhaseIterGVN &igvn() const { return _igvn; }
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -244,8 +244,11 @@ public:
   // try to hook me up to the exact initializing store.
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
 
+  // Return true if it's possible to split the Load through a Phi merging the bases
+  bool can_split_through_phi_base(PhaseGVN *phase);
+
   // Split instance field load through Phi.
-  Node* split_through_phi(PhaseGVN *phase);
+  Node* split_through_phi(PhaseGVN *phase, bool ignore_missing_instance_id = false);
 
   // Recover original value from boxed values
   Node *eliminate_autobox(PhaseIterGVN *igvn);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -158,6 +158,7 @@ class RegionNode;
 class RootNode;
 class SafePointNode;
 class SafePointScalarObjectNode;
+class SafePointScalarMergeNode;
 class StartNode;
 class State;
 class StoreNode;
@@ -726,6 +727,7 @@ public:
           DEFINE_CLASS_ID(UnorderedReduction, Reduction, 0)
       DEFINE_CLASS_ID(Con, Type, 8)
           DEFINE_CLASS_ID(ConI, Con, 0)
+      DEFINE_CLASS_ID(SafePointScalarMerge, Type, 9)
 
 
     DEFINE_CLASS_ID(Proj,  Node, 3)
@@ -953,6 +955,7 @@ public:
   DEFINE_CLASS_QUERY(Root)
   DEFINE_CLASS_QUERY(SafePoint)
   DEFINE_CLASS_QUERY(SafePointScalarObject)
+  DEFINE_CLASS_QUERY(SafePointScalarMerge)
   DEFINE_CLASS_QUERY(Start)
   DEFINE_CLASS_QUERY(Store)
   DEFINE_CLASS_QUERY(Sub)

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -749,7 +749,7 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
   if (local->is_SafePointScalarObject()) {
     SafePointScalarObjectNode* spobj = local->as_SafePointScalarObject();
 
-    ObjectValue* sv = sv_for_node_id(objs, spobj->_idx);
+    ObjectValue* sv = (ObjectValue*) sv_for_node_id(objs, spobj->_idx);
     if (sv == nullptr) {
       ciKlass* cik = t->is_oopptr()->exact_klass();
       assert(cik->is_instance_klass() ||
@@ -765,6 +765,31 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
       }
     }
     array->append(sv);
+    return;
+  } else if (local->is_SafePointScalarMerge()) {
+    SafePointScalarMergeNode* smerge = local->as_SafePointScalarMerge();
+    ObjectMergeValue* mv = (ObjectMergeValue*) sv_for_node_id(objs, smerge->_idx);
+
+    if (mv == NULL) {
+      GrowableArray<ScopeValue*> deps;
+
+      int merge_pointer_idx = smerge->merge_pointer_idx(sfpt->jvms());
+      (void)FillLocArray(0, sfpt, sfpt->in(merge_pointer_idx), &deps, objs);
+      assert(deps.length() == 1, "missing value");
+
+      int selector_idx = smerge->selector_idx(sfpt->jvms());
+      (void)FillLocArray(1, NULL, sfpt->in(selector_idx), &deps, NULL);
+      assert(deps.length() == 2, "missing value");
+
+      mv = new ObjectMergeValue(smerge->_idx, deps.at(0), deps.at(1));
+      set_sv_for_object_node(objs, mv);
+
+      for (uint i = 1; i < smerge->req(); i++) {
+        Node* obj_node = smerge->in(i);
+        (void)FillLocArray(mv->possible_objects()->length(), sfpt, obj_node, mv->possible_objects(), objs);
+      }
+    }
+    array->append(mv);
     return;
   }
 
@@ -931,6 +956,18 @@ bool PhaseOutput::starts_bundle(const Node *n) const {
           _node_bundling_base[n->_idx].starts_bundle());
 }
 
+// Determine if there is a monitor that has 'ov' as its owner.
+bool PhaseOutput::contains_as_owner(GrowableArray<MonitorValue*> *monarray, ObjectValue *ov) const {
+  for (int k = 0; k < monarray->length(); k++) {
+    MonitorValue* mv = monarray->at(k);
+    if (mv->owner() == ov) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 //--------------------------Process_OopMap_Node--------------------------------
 void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
   // Handle special safepoint nodes for synchronization
@@ -1059,6 +1096,21 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
       Location basic_lock = Location::new_stk_loc(Location::normal,C->regalloc()->reg2offset(box_reg));
       bool eliminated = (box_node->is_BoxLock() && box_node->as_BoxLock()->is_eliminated());
       monarray->append(new MonitorValue(scval, basic_lock, eliminated));
+    }
+
+    // Mark ObjectValue nodes as root nodes if they are directly
+    // referenced in the JVMS.
+    for (int i = 0; i < objs->length(); i++) {
+      ScopeValue* sv = objs->at(i);
+      if (sv->is_object_merge()) {
+        ObjectMergeValue* merge = sv->as_ObjectMergeValue();
+
+        for (int j = 0; j< merge->possible_objects()->length(); j++) {
+          ObjectValue* ov = merge->possible_objects()->at(j)->as_ObjectValue();
+          bool is_root = locarray->contains(ov) || exparray->contains(ov) || contains_as_owner(monarray, ov);
+          ov->set_root(is_root);
+        }
+      }
     }
 
     // We dump the object pool first, since deoptimization reads it in first.

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -210,6 +210,7 @@ public:
   bool valid_bundle_info(const Node *n);
 
   bool starts_bundle(const Node *n) const;
+  bool contains_as_owner(GrowableArray<MonitorValue*> *monarray, ObjectValue *ov) const;
 
   // Dump formatted assembly
 #if defined(SUPPORT_OPTO_ASSEMBLY)

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -276,11 +276,7 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
     SafePointNode* sfpt = safepoints.pop()->as_SafePoint();
 
     uint first_ind = (sfpt->req() - sfpt->jvms()->scloff());
-    Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(),
-#ifdef ASSERT
-                                               vec_box,
-#endif // ASSERT
-                                               first_ind, n_fields);
+    Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(), vec_box, first_ind, n_fields);
     sobj->init_req(0, C->root());
     sfpt->add_req(vec_value);
 

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -331,9 +331,9 @@ objArrayHandle LiveFrameStream::values_to_object_array(StackValueCollection* val
     int index = i;
 #ifdef _LP64
     if (type != T_OBJECT && type != T_CONFLICT) {
-        intptr_t ret = st->get_int(); // read full 64-bit slot
-        type = T_LONG;                // treat as long
-        index--;                      // undo +1 in StackValueCollection::long_at
+        intptr_t ret = st->get_intptr(); // read full 64-bit slot
+        type = T_LONG;                   // treat as long
+        index--;                         // undo +1 in StackValueCollection::long_at
     }
 #endif
     oop obj = create_primitive_slot_instance(values, index, type, CHECK_(empty));

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -329,7 +329,7 @@ static bool rematerialize_objects(JavaThread* thread, int exec_mode, CompiledMet
   assert(exec_mode == Deoptimization::Unpack_none || (deoptee_thread == thread),
          "a frame can only be deoptimized by the owner thread");
 
-  GrowableArray<ScopeValue*>* objects = chunk->at(0)->scope()->objects();
+  GrowableArray<ScopeValue*>* objects = chunk->at(0)->scope()->objects_to_rematerialize(deoptee, map);
 
   // The flag return_oop() indicates call sites which return oop
   // in compiled code. Such sites include java method calls,
@@ -1185,12 +1185,12 @@ oop Deoptimization::get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMa
    if (box_type != T_OBJECT) {
      StackValue* value = StackValue::create_stack_value(fr, reg_map, bv->field_at(box_type == T_LONG ? 1 : 0));
      switch(box_type) {
-       case T_INT:     return IntegerBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_CHAR:    return CharacterBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_SHORT:   return ShortBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_BYTE:    return ByteBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_BOOLEAN: return BooleanBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_LONG:    return LongBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
+       case T_INT:     return IntegerBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_CHAR:    return CharacterBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_SHORT:   return ShortBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_BYTE:    return ByteBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_BOOLEAN: return BooleanBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_LONG:    return LongBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
        default:;
      }
    }
@@ -1312,19 +1312,19 @@ static jbyte* check_alignment_get_addr(typeArrayOop obj, int index, int expected
     return res;
 }
 
-static void byte_array_put(typeArrayOop obj, intptr_t val, int index, int byte_count) {
+static void byte_array_put(typeArrayOop obj, StackValue* value, int index, int byte_count) {
   switch (byte_count) {
     case 1:
-      obj->byte_at_put(index, (jbyte) *((jint *) &val));
+      obj->byte_at_put(index, (jbyte) value->get_jint());
       break;
     case 2:
-      *((jshort *) check_alignment_get_addr(obj, index, 2)) = (jshort) *((jint *) &val);
+      *((jshort *) check_alignment_get_addr(obj, index, 2)) = (jshort) value->get_jint();
       break;
     case 4:
-      *((jint *) check_alignment_get_addr(obj, index, 4)) = (jint) *((jint *) &val);
+      *((jint *) check_alignment_get_addr(obj, index, 4)) = value->get_jint();
       break;
     case 8:
-      *((jlong *) check_alignment_get_addr(obj, index, 8)) = (jlong) *((jlong *) &val);
+      *((jlong *) check_alignment_get_addr(obj, index, 8)) = (jlong) value->get_intptr();
       break;
     default:
       ShouldNotReachHere();
@@ -1336,7 +1336,6 @@ static void byte_array_put(typeArrayOop obj, intptr_t val, int index, int byte_c
 // restore elements of an eliminated type array
 void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type) {
   int index = 0;
-  intptr_t val;
 
   for (int i = 0; i < sv->field_size(); i++) {
     StackValue* value = StackValue::create_stack_value(fr, reg_map, sv->field_at(i));
@@ -1346,15 +1345,14 @@ void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_ma
       StackValue* low =
         StackValue::create_stack_value(fr, reg_map, sv->field_at(++i));
 #ifdef _LP64
-      jlong res = (jlong)low->get_int();
+      jlong res = (jlong)low->get_intptr();
 #else
-      jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+      jlong res = jlong_from(value->get_jint(), low->get_jint());
 #endif
       obj->long_at_put(index, res);
       break;
     }
 
-    // Have to cast to INT (32 bits) pointer to avoid little/big-endian problem.
     case T_INT: case T_FLOAT: { // 4 bytes.
       assert(value->type() == T_INT, "Agreement.");
       bool big_value = false;
@@ -1375,53 +1373,48 @@ void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_ma
       if (big_value) {
         StackValue* low = StackValue::create_stack_value(fr, reg_map, sv->field_at(++i));
   #ifdef _LP64
-        jlong res = (jlong)low->get_int();
+        jlong res = (jlong)low->get_intptr();
   #else
-        jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+        jlong res = jlong_from(value->get_jint(), low->get_jint());
   #endif
-        obj->int_at_put(index, (jint)*((jint*)&res));
-        obj->int_at_put(++index, (jint)*(((jint*)&res) + 1));
+        obj->int_at_put(index, *(jint*)&res);
+        obj->int_at_put(++index, *((jint*)&res + 1));
       } else {
-        val = value->get_int();
-        obj->int_at_put(index, (jint)*((jint*)&val));
+        obj->int_at_put(index, value->get_jint());
       }
       break;
     }
 
     case T_SHORT:
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->short_at_put(index, (jshort)*((jint*)&val));
+      obj->short_at_put(index, (jshort)value->get_jint());
       break;
 
     case T_CHAR:
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->char_at_put(index, (jchar)*((jint*)&val));
+      obj->char_at_put(index, (jchar)value->get_jint());
       break;
 
     case T_BYTE: {
       assert(value->type() == T_INT, "Agreement.");
-      // The value we get is erased as a regular int. We will need to find its actual byte count 'by hand'.
-      val = value->get_int();
 #if INCLUDE_JVMCI
+      // The value we get is erased as a regular int. We will need to find its actual byte count 'by hand'.
       int byte_count = count_number_of_bytes_for_entry(sv, i);
-      byte_array_put(obj, val, index, byte_count);
+      byte_array_put(obj, value, index, byte_count);
       // According to byte_count contract, the values from i + 1 to i + byte_count are illegal values. Skip.
       i += byte_count - 1; // Balance the loop counter.
       index += byte_count;
       // index has been updated so continue at top of loop
       continue;
 #else
-      obj->byte_at_put(index, (jbyte)*((jint*)&val));
+      obj->byte_at_put(index, (jbyte)value->get_jint());
       break;
 #endif // INCLUDE_JVMCI
     }
 
     case T_BOOLEAN: {
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->bool_at_put(index, (jboolean)*((jint*)&val));
+      obj->bool_at_put(index, (jboolean)value->get_jint());
       break;
     }
 
@@ -1474,7 +1467,6 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
   }
   fields->sort(compare);
   for (int i = 0; i < fields->length(); i++) {
-    intptr_t val;
     ScopeValue* scope_field = sv->field_at(svIndex);
     StackValue* value = StackValue::create_stack_value(fr, reg_map, scope_field);
     int offset = fields->at(i)._offset;
@@ -1485,7 +1477,6 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         obj->obj_field_put(offset, value->get_obj()());
         break;
 
-      // Have to cast to INT (32 bits) pointer to avoid little/big-endian problem.
       case T_INT: case T_FLOAT: { // 4 bytes.
         assert(value->type() == T_INT, "Agreement.");
         bool big_value = false;
@@ -1509,8 +1500,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
           assert(i < fields->length(), "second T_INT field needed");
           assert(fields->at(i)._type == T_INT, "T_INT field needed");
         } else {
-          val = value->get_int();
-          obj->int_field_put(offset, (jint)*((jint*)&val));
+          obj->int_field_put(offset, value->get_jint());
           break;
         }
       }
@@ -1520,9 +1510,9 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         assert(value->type() == T_INT, "Agreement.");
         StackValue* low = StackValue::create_stack_value(fr, reg_map, sv->field_at(++svIndex));
 #ifdef _LP64
-        jlong res = (jlong)low->get_int();
+        jlong res = (jlong)low->get_intptr();
 #else
-        jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+        jlong res = jlong_from(value->get_jint(), low->get_jint());
 #endif
         obj->long_field_put(offset, res);
         break;
@@ -1530,26 +1520,22 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
 
       case T_SHORT:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->short_field_put(offset, (jshort)*((jint*)&val));
+        obj->short_field_put(offset, (jshort)value->get_jint());
         break;
 
       case T_CHAR:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->char_field_put(offset, (jchar)*((jint*)&val));
+        obj->char_field_put(offset, (jchar)value->get_jint());
         break;
 
       case T_BYTE:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->byte_field_put(offset, (jbyte)*((jint*)&val));
+        obj->byte_field_put(offset, (jbyte)value->get_jint());
         break;
 
       case T_BOOLEAN:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->bool_field_put(offset, (jboolean)*((jint*)&val));
+        obj->bool_field_put(offset, (jboolean)value->get_jint());
         break;
 
       default:
@@ -1563,6 +1549,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
 // restore fields of all eliminated objects and arrays
 void Deoptimization::reassign_fields(frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, bool realloc_failures, bool skip_internal) {
   for (int i = 0; i < objects->length(); i++) {
+    assert(objects->at(i)->is_object(), "invalid debug information");
     ObjectValue* sv = (ObjectValue*) objects->at(i);
     Klass* k = java_lang_Class::as_Klass(sv->klass()->as_ConstantOopReadValue()->value()());
     Handle obj = sv->value();

--- a/src/hotspot/share/runtime/stackValue.hpp
+++ b/src/hotspot/share/runtime/stackValue.hpp
@@ -79,20 +79,32 @@ class StackValue : public ResourceObj {
     _handle_value = value;
   }
 
-  intptr_t get_int() const {
+  intptr_t get_intptr() const {
     assert(type() == T_INT, "type check");
     return _integer_value;
   }
 
   // For special case in deopt.
-  intptr_t get_int(BasicType t) const {
+  intptr_t get_intptr(BasicType t) const {
     assert(t == T_OBJECT && type() == T_OBJECT, "type check");
     return _integer_value;
   }
 
-  void set_int(intptr_t value) {
+  void set_intptr(intptr_t value) {
     assert(type() == T_INT, "type check");
     _integer_value = value;
+  }
+
+  // The jint value is always at offset 0 of the stack slot. On big endian platforms
+  // this is the location of the high word therefore we cannot just cast to jint.
+  jint get_jint() const {
+    assert(type() == T_INT, "type check");
+    return *(jint*)&_integer_value;
+  }
+
+  void set_jint(jint value) {
+    assert(type() == T_INT, "type check");
+    *(jint*)&_integer_value = value;
   }
 
   BasicType type() const { return  _type; }

--- a/src/hotspot/share/runtime/stackValueCollection.cpp
+++ b/src/hotspot/share/runtime/stackValueCollection.cpp
@@ -26,14 +26,12 @@
 #include "runtime/stackValueCollection.hpp"
 
 jint StackValueCollection::int_at(int slot) const {
-  intptr_t val =  at(slot)->get_int();
-  jint ival = *((jint*) (&val));
-  return ival;
+  return at(slot)->get_jint();
 }
 
 jlong StackValueCollection::long_at(int slot) const {
 #ifdef _LP64
-  return at(slot+1)->get_int();
+  return at(slot+1)->get_intptr();
 #else
   union {
     jlong jl;
@@ -41,8 +39,8 @@ jlong StackValueCollection::long_at(int slot) const {
   } value;
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  value.array[0] = at(slot+1)->get_int();
-  value.array[1] = at(slot  )->get_int();
+  value.array[0] = at(slot+1)->get_intptr();
+  value.array[1] = at(slot  )->get_intptr();
   return value.jl;
 #endif
 }
@@ -52,13 +50,13 @@ Handle StackValueCollection::obj_at(int slot) const {
 }
 
 jfloat StackValueCollection::float_at(int slot) const {
-  intptr_t res = at(slot)->get_int();
+  intptr_t res = at(slot)->get_intptr();
   return *((jfloat*) (&res));
 }
 
 jdouble StackValueCollection::double_at(int slot) const {
 #ifdef _LP64
-  intptr_t res = at(slot+1)->get_int();
+  intptr_t res = at(slot+1)->get_intptr();
   return *((jdouble*) (&res));
 #else
   union {
@@ -67,21 +65,19 @@ jdouble StackValueCollection::double_at(int slot) const {
   } value;
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  value.array[0] = at(slot+1)->get_int();
-  value.array[1] = at(slot  )->get_int();
+  value.array[0] = at(slot+1)->get_intptr();
+  value.array[1] = at(slot  )->get_intptr();
   return value.jd;
 #endif
 }
 
 void StackValueCollection::set_int_at(int slot, jint value) {
-  intptr_t val;
-  *((jint*) (&val)) = value;
-  at(slot)->set_int(val);
+  at(slot)->set_jint(value);
 }
 
 void StackValueCollection::set_long_at(int slot, jlong value) {
 #ifdef _LP64
-  at(slot+1)->set_int(value);
+  at(slot+1)->set_intptr(value);
 #else
   union {
     jlong jl;
@@ -90,8 +86,8 @@ void StackValueCollection::set_long_at(int slot, jlong value) {
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
   x.jl = value;
-  at(slot+1)->set_int(x.array[0]);
-  at(slot+0)->set_int(x.array[1]);
+  at(slot+1)->set_intptr(x.array[0]);
+  at(slot+0)->set_intptr(x.array[1]);
 #endif
 }
 
@@ -108,15 +104,15 @@ void StackValueCollection::set_float_at(int slot, jfloat value) {
   // Interpreter stores 32 bit floats in first half of 64 bit word.
   val.array[0] = *(jint*)(&value);
   val.array[1] = 0;
-  at(slot)->set_int(val.jd);
+  at(slot)->set_intptr(val.jd);
 #else
-  at(slot)->set_int(*(jint*)(&value));
+  at(slot)->set_intptr(*(jint*)(&value));
 #endif
 }
 
 void StackValueCollection::set_double_at(int slot, jdouble value) {
 #ifdef _LP64
-  at(slot+1)->set_int(*(intptr_t*)(&value));
+  at(slot+1)->set_intptr(*(intptr_t*)(&value));
 #else
   union {
     jdouble jd;
@@ -125,8 +121,8 @@ void StackValueCollection::set_double_at(int slot, jdouble value) {
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
   x.jd = value;
-  at(slot+1)->set_int(x.array[0]);
-  at(slot+0)->set_int(x.array[1]);
+  at(slot+1)->set_intptr(x.array[0]);
+  at(slot+0)->set_intptr(x.array[1]);
 #endif
 }
 

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -453,7 +453,7 @@ void interpretedVFrame::set_locals(StackValueCollection* values) const {
     if (sv->type() == T_OBJECT) {
       *(oop *) addr = (sv->get_obj())();
     } else {                   // integer
-      *addr = sv->get_int();
+      *addr = sv->get_intptr();
     }
   }
 }

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -133,7 +133,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
         _locals->add( new StackValue());
         break;
       case T_INT:
-        _locals->add( new StackValue(value->get_int()));
+        _locals->add( new StackValue(value->get_intptr()));
         break;
       default:
         ShouldNotReachHere();
@@ -160,7 +160,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
         _expressions->add( new StackValue());
         break;
       case T_INT:
-        _expressions->add( new StackValue(value->get_int()));
+        _expressions->add( new StackValue(value->get_intptr()));
         break;
       default:
         ShouldNotReachHere();
@@ -342,7 +342,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     assert(!is_bottom_frame || !(caller->is_compiled_caller() && addr >= caller->unextended_sp()), "overwriting caller frame!");
     switch(value->type()) {
       case T_INT:
-        *addr = value->get_int();
+        *addr = value->get_intptr();
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print_cr(" - Reconstructed expression %d (INT): %d", i, (int)(*addr));
@@ -350,7 +350,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
 #endif // !PRODUCT
         break;
       case T_OBJECT:
-        *addr = value->get_int(T_OBJECT);
+        *addr = value->get_intptr(T_OBJECT);
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print(" - Reconstructed expression %d (OBJECT): ", i);
@@ -386,7 +386,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     assert(!is_bottom_frame || !(caller->is_compiled_caller() && addr >= caller->unextended_sp()), "overwriting caller frame!");
     switch(value->type()) {
       case T_INT:
-        *addr = value->get_int();
+        *addr = value->get_intptr();
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print_cr(" - Reconstructed local %d (INT): %d", i, (int)(*addr));
@@ -394,7 +394,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
 #endif // !PRODUCT
         break;
       case T_OBJECT:
-        *addr = value->get_int(T_OBJECT);
+        *addr = value->get_intptr(T_OBJECT);
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print(" - Reconstructed local %d (OBJECT): ", i);

--- a/src/java.base/share/classes/java/security/AccessController.java
+++ b/src/java.base/share/classes/java/security/AccessController.java
@@ -778,6 +778,13 @@ public final class AccessController {
         T result = action.run();
         assert isPrivileged(); // sanity check invariant
 
+        // The 'getStackAccessControlContext' call inside 'isPrivileged'
+        // requires that no Local was scalar replaced. However, in some
+        // situations, after inlining, 'result' (or part of a possibly
+        // allocation merge Phi leading to it) might become NonEscaping and get
+        // scalar replaced. The call below enforces 'result' to always escape.
+        ensureMaterializedForStackWalk(result);
+
         // Keep these alive across the run() call so they can be
         // retrieved by getStackAccessControlContext().
         Reference.reachabilityFence(context);
@@ -808,6 +815,13 @@ public final class AccessController {
         assert isPrivileged(); // sanity check invariant
         T result = action.run();
         assert isPrivileged(); // sanity check invariant
+
+        // The 'getStackAccessControlContext' call inside 'isPrivileged'
+        // requires that no Local was scalar replaced. However, in some
+        // situations, after inlining, 'result' (or part of a possibly
+        // allocation merge Phi leading to it) might become NonEscaping and get
+        // scalar replaced. The call below enforces 'result' to always escape.
+        ensureMaterializedForStackWalk(result);
 
         // Keep these alive across the run() call so they can be
         // retrieved by getStackAccessControlContext().

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -1,0 +1,1420 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.scalarReplacement;
+
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8281429
+ * @summary Tests that C2 can correctly scalar replace some object allocation merges.
+ * @library /test/lib /
+ * @requires vm.debug == true & vm.bits == 64 & vm.compiler2.enabled & vm.opt.final.UseCompressedOops & vm.opt.final.EliminateAllocations
+ * @run driver compiler.c2.irTests.scalarReplacement.AllocationMergesTests
+ */
+public class AllocationMergesTests {
+    private int invocations = 0;
+    private static Point global_escape = new Point(2022, 2023);
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
+                                   "-XX:+ReduceAllocationMerges",
+                                   "-XX:+TraceReduceAllocationMerges",
+                                   "-XX:+DeoptimizeALot",
+                                   "-XX:CompileCommand=inline,*::charAt*",
+                                   "-XX:CompileCommand=inline,*PicturePositions::*",
+                                   "-XX:CompileCommand=inline,*Point::*",
+                                   "-XX:CompileCommand=exclude,*::dummy*");
+    }
+
+    // ------------------ No Scalar Replacement Should Happen in The Tests Below ------------------- //
+
+    @Run(test = {"testGlobalEscape_C2",
+                 "testArgEscape_C2",
+                 "testEscapeInCallAfterMerge_C2",
+                 "testNoEscapeWithWriteInLoop_C2",
+                 "testPollutedWithWrite_C2",
+                 "testPollutedPolymorphic_C2",
+                 "testMergedLoadAfterDirectStore_C2",
+                 "testMergedAccessAfterCallWithWrite_C2",
+                 "testLoadAfterTrap_C2",
+                 "testCondAfterMergeWithNull_C2",
+                 "testLoadAfterLoopAlias_C2",
+                 "testCallTwoSide_C2",
+                 "testMergedAccessAfterCallNoWrite_C2",
+                 "testCmpMergeWithNull_Second_C2",
+                 "testObjectIdentity_C2",
+                 "testSubclassesTrapping_C2",
+                 "testCmpMergeWithNull_C2",
+                 "testSubclasses_C2",
+                 "testPartialPhis_C2",
+                 "testPollutedNoWrite_C2",
+                 "testThreeWayAliasedAlloc_C2",
+                 "TestTrapAfterMerge_C2",
+                 "testNestedObjectsObject_C2",
+                 "testNestedObjectsNoEscapeObject_C2",
+                 "testNestedObjectsArray_C2",
+                 "testTrappingAfterMerge_C2",
+                 "testSimpleAliasedAlloc_C2",
+                 "testSimpleDoubleMerge_C2",
+                 "testConsecutiveSimpleMerge_C2",
+                 "testDoubleIfElseMerge_C2",
+                 "testNoEscapeWithLoadInLoop_C2",
+                 "testCmpAfterMerge_C2",
+                 "testCondAfterMergeWithAllocate_C2",
+                 "testCondLoadAfterMerge_C2",
+                 "testIfElseInLoop_C2",
+                 "testLoadInCondAfterMerge_C2",
+                 "testLoadInLoop_C2",
+                 "testMergesAndMixedEscape_C2",
+                 "testSRAndNSR_NoTrap_C2",
+                 "testSRAndNSR_Trap_C2",
+                 "testString_one_C2",
+                 "testString_two_C2"
+                })
+    public void runner(RunInfo info) {
+        invocations++;
+
+        Random random = info.getRandom();
+        boolean cond1 = invocations % 2 == 0;
+        boolean cond2 = !cond1;
+
+        int l = random.nextInt();
+        int w = random.nextInt();
+        int x = random.nextInt();
+        int y = random.nextInt();
+        int z = random.nextInt();
+
+        Asserts.assertEQ(testGlobalEscape_Interp(x, y),                             testGlobalEscape_C2(x, y));
+        Asserts.assertEQ(testArgEscape_Interp(x, y),                                testArgEscape_C2(x, y));
+        Asserts.assertEQ(testEscapeInCallAfterMerge_Interp(cond1, cond2, x, y),     testEscapeInCallAfterMerge_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNoEscapeWithWriteInLoop_Interp(cond1, cond2, x, y),    testNoEscapeWithWriteInLoop_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testPollutedWithWrite_Interp(cond1, x),                    testPollutedWithWrite_C2(cond1, x));
+        Asserts.assertEQ(testPollutedPolymorphic_Interp(cond1, x),                  testPollutedPolymorphic_C2(cond1, x));
+        Asserts.assertEQ(testMergedLoadAfterDirectStore_Interp(cond1, x, y),        testMergedLoadAfterDirectStore_C2(cond1, x, y));
+        Asserts.assertEQ(testMergedAccessAfterCallWithWrite_Interp(cond1, x, y),    testMergedAccessAfterCallWithWrite_C2(cond1, x, y));
+        Asserts.assertEQ(testLoadAfterTrap_Interp(cond1, x, y),                     testLoadAfterTrap_C2(cond1, x, y));
+        Asserts.assertEQ(testCondAfterMergeWithNull_Interp(cond1, cond2, x, y),     testCondAfterMergeWithNull_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testLoadAfterLoopAlias_Interp(cond1, x, y),                testLoadAfterLoopAlias_C2(cond1, x, y));
+        Asserts.assertEQ(testCallTwoSide_Interp(cond1, x, y),                       testCallTwoSide_C2(cond1, x, y));
+        Asserts.assertEQ(testMergedAccessAfterCallNoWrite_Interp(cond1, x, y),      testMergedAccessAfterCallNoWrite_C2(cond1, x, y));
+        Asserts.assertEQ(testCmpMergeWithNull_Second_Interp(cond1, x, y),           testCmpMergeWithNull_Second_C2(cond1, x, y));
+        Asserts.assertEQ(testObjectIdentity_Interp(cond1, 42, y),                   testObjectIdentity_C2(cond1, 42, y));
+        Asserts.assertEQ(testSubclassesTrapping_Interp(cond1, cond2, x, y, w, z),   testSubclassesTrapping_C2(cond1, cond2, x, y, w, z));
+        Asserts.assertEQ(testCmpMergeWithNull_Interp(cond1, x, y),                  testCmpMergeWithNull_C2(cond1, x, y));
+        Asserts.assertEQ(testSubclasses_Interp(cond1, cond2, x, y, w, z),           testSubclasses_C2(cond1, cond2, x, y, w, z));
+        Asserts.assertEQ(testPartialPhis_Interp(cond1, l, x, y),                    testPartialPhis_C2(cond1, l, x, y));
+        Asserts.assertEQ(testPollutedNoWrite_Interp(cond1, l),                      testPollutedNoWrite_C2(cond1, l));
+        Asserts.assertEQ(testThreeWayAliasedAlloc_Interp(cond1, x, y),              testThreeWayAliasedAlloc_C2(cond1, x, y));
+        Asserts.assertEQ(TestTrapAfterMerge_Interp(cond1, x, y),                    TestTrapAfterMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testNestedObjectsObject_Interp(cond1, x, y),               testNestedObjectsObject_C2(cond1, x, y));
+        Asserts.assertEQ(testNestedObjectsNoEscapeObject_Interp(cond1, x, y),       testNestedObjectsNoEscapeObject_C2(cond1, x, y));
+        Asserts.assertEQ(testTrappingAfterMerge_Interp(cond1, x, y),                testTrappingAfterMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testSimpleAliasedAlloc_Interp(cond1, x, y),                testSimpleAliasedAlloc_C2(cond1, x, y));
+        Asserts.assertEQ(testSimpleDoubleMerge_Interp(cond1, x, y),                 testSimpleDoubleMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testConsecutiveSimpleMerge_Interp(cond1, cond2, x, y),     testConsecutiveSimpleMerge_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testDoubleIfElseMerge_Interp(cond1, x, y),                 testDoubleIfElseMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testNoEscapeWithLoadInLoop_Interp(cond1, x, y),            testNoEscapeWithLoadInLoop_C2(cond1, x, y));
+        Asserts.assertEQ(testCmpAfterMerge_Interp(cond1, cond2, x, y),              testCmpAfterMerge_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testCondAfterMergeWithAllocate_Interp(cond1, cond2, x, y), testCondAfterMergeWithAllocate_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testCondLoadAfterMerge_Interp(cond1, cond2, x, y),         testCondLoadAfterMerge_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testIfElseInLoop_Interp(),                                 testIfElseInLoop_C2());
+        Asserts.assertEQ(testLoadInCondAfterMerge_Interp(cond1, x, y),              testLoadInCondAfterMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testLoadInLoop_Interp(cond1, x, y),                        testLoadInLoop_C2(cond1, x, y));
+        Asserts.assertEQ(testMergesAndMixedEscape_Interp(cond1, x, y),              testMergesAndMixedEscape_C2(cond1, x, y));
+        Asserts.assertEQ(testSRAndNSR_NoTrap_Interp(cond1, x, y),                   testSRAndNSR_NoTrap_C2(cond1, x, y));
+        Asserts.assertEQ(testString_one_Interp(cond1),                              testString_one_C2(cond1));
+        Asserts.assertEQ(testString_two_Interp(cond1),                              testString_two_C2(cond1));
+
+        Asserts.assertEQ(testSRAndNSR_Trap_Interp(false, cond1, cond2, x, y),
+                         testSRAndNSR_Trap_C2(info.isTestC2Compiled("testSRAndNSR_Trap_C2"), cond1, cond2, x, y));
+
+        var arr1 = testNestedObjectsArray_Interp(cond1, x, y);
+        var arr2 = testNestedObjectsArray_C2(cond1, x, y);
+
+        if (arr1.length != arr2.length) Asserts.fail("testNestedObjectsArray result size mismatch.");
+        for (int i=0; i<arr1.length; i++) {
+            if (!arr1[i].equals(arr2[i])) {
+                Asserts.fail("testNestedObjectsArray objects mismatch.");
+            }
+        }
+
+    }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testGlobalEscape(int x, int y) {
+        Point p = new Point(x, y);
+
+        AllocationMergesTests.global_escape = p;
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testGlobalEscape_C2(int x, int y) { return testGlobalEscape(x, y); }
+
+    @DontCompile
+    int testGlobalEscape_Interp(int x, int y) { return testGlobalEscape(x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testArgEscape(int x, int y) {
+        Point p = new Point(x, y);
+
+        int val = dummy(p);
+
+        return val + p.x + p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    int testArgEscape_C2(int x, int y) { return testArgEscape(x, y); }
+
+    @DontCompile
+    int testArgEscape_Interp(int x, int y) { return testArgEscape(x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testEscapeInCallAfterMerge(boolean cond, boolean cond2, int x, int y) {
+        Point p = new Point(x, x);
+
+        if (cond) {
+            p = new Point(y, y);
+        }
+
+        if (cond2) {
+            dummy(p);
+        }
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    int testEscapeInCallAfterMerge_C2(boolean cond, boolean cond2, int x, int y) { return testEscapeInCallAfterMerge(cond, cond2, x, y); }
+
+    @DontCompile
+    int testEscapeInCallAfterMerge_Interp(boolean cond, boolean cond2, int x, int y) { return testEscapeInCallAfterMerge(cond, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testNoEscapeWithWriteInLoop(boolean cond, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond) {
+            p = new Point(y, x);
+        }
+
+        for (int i=0; i<100; i++) {
+            p.x += p.y + i;
+            p.y += p.x + i;
+        }
+
+        return res + p.x + p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because of the write to the fields
+    int testNoEscapeWithWriteInLoop_C2(boolean cond, boolean cond2, int x, int y) { return testNoEscapeWithWriteInLoop(cond, cond2, x, y); }
+
+    @DontCompile
+    int testNoEscapeWithWriteInLoop_Interp(boolean cond, boolean cond2, int x, int y) { return testNoEscapeWithWriteInLoop(cond, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testPollutedWithWrite(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Square(l);
+        Shape obj = null;
+
+        if (cond) {
+            obj = obj1;
+        } else {
+            obj = obj2;
+        }
+
+        for (int i=1; i<132; i++) {
+            obj.x++;
+        }
+
+        return obj1.x + obj2.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because of the write to the field
+    int testPollutedWithWrite_C2(boolean cond, int l) { return testPollutedWithWrite(cond, l); }
+
+    @DontCompile
+    int testPollutedWithWrite_Interp(boolean cond, int l) { return testPollutedWithWrite(cond, l); }
+
+    // -------------------------------------------------------------------------
+    @ForceInline
+    int testPollutedPolymorphic(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Circle(l);
+        Shape obj = (cond ? obj1 : obj2);
+        int res = 0;
+
+        for (int i=1; i<232; i++) {
+            res += obj.x;
+        }
+
+        return res + obj1.x + obj2.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because the inputs to the Phi have different Klasses
+    int testPollutedPolymorphic_C2(boolean cond, int l) { return testPollutedPolymorphic(cond, l); }
+
+    @DontCompile
+    int testPollutedPolymorphic_Interp(boolean cond, int l) { return testPollutedPolymorphic(cond, l); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testMergedLoadAfterDirectStore(boolean cond, int x, int y) {
+        Point p0 = new Point(x, x);
+        Point p1 = new Point(y, y);
+        Point p = null;
+
+        if (cond) {
+            p = p0;
+        } else {
+            p = p1;
+        }
+
+        p0.x = x * y;
+
+        return p.x;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // Merge won't be reduced because write to one of the inputs *after* the merge
+    int testMergedLoadAfterDirectStore_C2(boolean cond, int x, int y) { return testMergedLoadAfterDirectStore(cond, x, y); }
+
+    @DontCompile
+    int testMergedLoadAfterDirectStore_Interp(boolean cond, int x, int y) { return testMergedLoadAfterDirectStore(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testMergedAccessAfterCallWithWrite(boolean cond, int x, int y) {
+        Point p2 = new Point(x, x);
+        Point p = new Point(y, y);
+
+        p.x = p.x * y;
+
+        if (cond) {
+            p = new Point(x, x);
+        }
+
+        dummy(p2);
+
+        for (int i=3; i<324; i++) {
+            p.x += i * x;
+        }
+
+        return p.x;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" })
+    // Objects won't be scalar replaced because:
+    //  - p is written inside the loop.
+    //  - p2 is ArgEscape
+    int testMergedAccessAfterCallWithWrite_C2(boolean cond, int x, int y) { return testMergedAccessAfterCallWithWrite(cond, x, y); }
+
+    @DontCompile
+    int testMergedAccessAfterCallWithWrite_Interp(boolean cond, int x, int y) { return testMergedAccessAfterCallWithWrite(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testLoadAfterTrap(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond) {
+            p = new Point(x, x);
+        } else {
+            p = new Point(y, y);
+        }
+
+        dummy(x+y);
+
+        return p.x + p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // The allocations won't be removed because 'split_through_phi' won't split the load through the bases.
+    int testLoadAfterTrap_C2(boolean cond, int x, int y) { return testLoadAfterTrap(cond, x, y); }
+
+    @DontCompile
+    int testLoadAfterTrap_Interp(boolean cond, int x, int y) { return testLoadAfterTrap(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCondAfterMergeWithNull(boolean cond1, boolean cond2, int x, int y) {
+        Point p = null;
+
+        if (cond1) {
+            p = new Point(y, x);
+        }
+
+        if (cond2 && cond1) {
+            return p.x;
+        } else {
+            return 321;
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // The merge won't be simplified because the merge with NULL
+    int testCondAfterMergeWithNull_C2(boolean cond1, boolean cond2, int x, int y) { return testCondAfterMergeWithNull(cond1, cond2, x, y); }
+
+    @DontCompile
+    int testCondAfterMergeWithNull_Interp(boolean cond1, boolean cond2, int x, int y) { return testCondAfterMergeWithNull(cond1, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testLoadAfterLoopAlias(boolean cond, int x, int y) {
+        Point a = new Point(x, y);
+        Point b = new Point(y, x);
+        Point c = a;
+
+        for (int i=10; i<232; i++) {
+            if (i == x) {
+                c = b;
+            }
+        }
+
+        return cond ? c.x : c.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations should be removed
+    int testLoadAfterLoopAlias_C2(boolean cond, int x, int y) { return testLoadAfterLoopAlias(cond, x, y); }
+
+    @DontCompile
+    int testLoadAfterLoopAlias_Interp(boolean cond, int x, int y) { return testLoadAfterLoopAlias(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCallTwoSide(boolean cond1, int x, int y) {
+        Point p = dummy(x, y);
+
+        if (cond1) {
+            p = dummy(y, x);
+        }
+
+        return (p != null) ? p.x : 0;
+    }
+
+    @Test
+    @IR(counts = { IRNode.CALL, "<=3" })
+    // Merge won't be reduced because both of the inputs are NSR.
+    // There could be 3 call nodes because one if can became an unstable trap.
+    int testCallTwoSide_C2(boolean cond1, int x, int y) { return testCallTwoSide(cond1, x, y); }
+
+    @DontCompile
+    int testCallTwoSide_Interp(boolean cond1, int x, int y) { return testCallTwoSide(cond1, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testMergedAccessAfterCallNoWrite(boolean cond, int x, int y) {
+        Point p2 = new Point(x, x);
+        Point p = new Point(y, y);
+        int res = 0;
+
+        p.x = p.x * y;
+
+        if (cond) {
+            p = new Point(y, y);
+        }
+
+        dummy(p2);
+
+        for (int i=3; i<324; i++) {
+            res += p.x + i * x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" })
+    // p2 escapes and therefore won't be removed.
+    // The allocations won't be removed because 'split_through_phi' won't split the load through the bases.
+    int testMergedAccessAfterCallNoWrite_C2(boolean cond, int x, int y) { return testMergedAccessAfterCallNoWrite(cond, x, y); }
+
+    @DontCompile
+    int testMergedAccessAfterCallNoWrite_Interp(boolean cond, int x, int y) { return testMergedAccessAfterCallNoWrite(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCmpMergeWithNull_Second(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond) {
+            p = new Point(x*x, y*y);
+        }
+
+        dummy(x);
+
+        if (p != null) {
+            return p.x * p.y;
+        } else {
+            return 1984;
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // Merge won't be reduced because, among other things, one of the inputs is null.
+    int testCmpMergeWithNull_Second_C2(boolean cond, int x, int y) { return testCmpMergeWithNull_Second(cond, x, y); }
+
+    @DontCompile
+    int testCmpMergeWithNull_Second_Interp(boolean cond, int x, int y) { return testCmpMergeWithNull_Second(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testObjectIdentity(boolean cond, int x, int y) {
+        Point o = new Point(x, y);
+
+        if (cond && x == 42) {
+            o = global_escape;
+        }
+
+        return o.x + o.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // The allocation won't be removed because the merge doesn't have exact type
+    int testObjectIdentity_C2(boolean cond, int x, int y) { return testObjectIdentity(cond, x, y); }
+
+    @DontCompile
+    int testObjectIdentity_Interp(boolean cond, int x, int y) { return testObjectIdentity(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSubclassesTrapping(boolean c1, boolean c2, int x, int y, int w, int z) {
+        new A();
+        Root s = new Home(x, y);
+        new B();
+
+        if (c1) {
+            new C();
+            s = new Etc("Hello");
+            new D();
+        } else {
+            new E();
+            s = new Usr(y, x, z);
+            new F();
+        }
+
+        int res = s.a;
+        dummy();
+
+        return res;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // The initial allocation assigned to 's' will always be dead.
+    // The other two allocations assigned to 's' won't be removed because they have different type.
+    int testSubclassesTrapping_C2(boolean c1, boolean c2, int x, int y, int w, int z) { return testSubclassesTrapping(c1, c2, x, y, w, z); }
+
+    @DontCompile
+    int testSubclassesTrapping_Interp(boolean c1, boolean c2, int x, int y, int w, int z) { return testSubclassesTrapping(c1, c2, x, y, w, z); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCmpMergeWithNull(boolean cond, int x, int y) {
+        Point p = null;
+
+        if (cond) {
+            p = new Point(x*x, y*y);
+        } else if (x > y) {
+            p = new Point(x+y, x*y);
+        }
+
+        if (p != null) {
+            return p.x * p.y;
+        } else {
+            return 1984;
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    int testCmpMergeWithNull_C2(boolean cond, int x, int y) { return testCmpMergeWithNull(cond, x, y); }
+
+    @DontCompile
+    int testCmpMergeWithNull_Interp(boolean cond, int x, int y) { return testCmpMergeWithNull(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSubclasses(boolean c1, boolean c2, int x, int y, int w, int z) {
+        new A();
+        Root s = new Home(x, y);
+        new B();
+
+        if (c1) {
+            new C();
+            s = new Etc("Hello");
+            new D();
+        } else {
+            new E();
+            s = new Usr(y, x, z);
+            new F();
+        }
+
+        new G();
+
+        return s.a;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // The unused allocation will be removed.
+    // The other two allocations assigned to 's' won't be removed because they have different type.
+    int testSubclasses_C2(boolean c1, boolean c2, int x, int y, int w, int z) { return testSubclasses(c1, c2, x, y, w, z); }
+
+    @DontCompile
+    int testSubclasses_Interp(boolean c1, boolean c2, int x, int y, int w, int z) { return testSubclasses(c1, c2, x, y, w, z); }
+
+
+    // ------------------ Some Scalar Replacement Should Happen in The Tests Below ------------------- //
+
+    @ForceInline
+    int testPartialPhis(boolean cond, int l, int x, int y) {
+        int k = l;
+
+        if (l == 0) {
+            k = l + 1;
+        } else if (l == 2) {
+            k = l + 2;
+        } else if (l == 3) {
+            new Point(x, y);
+        } else if (l == 4) {
+            new Point(y, x);
+        }
+
+        return k;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // all allocations will be dead
+    int testPartialPhis_C2(boolean cond, int l, int x, int y) { return testPartialPhis(cond, l, x, y); }
+
+    @DontCompile
+    int testPartialPhis_Interp(boolean cond, int l, int x, int y) { return testPartialPhis(cond, l, x, y); }
+
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testPollutedNoWrite(boolean cond, int l) {
+        Shape obj1 = new Square(l);
+        Shape obj2 = new Square(l);
+        Shape obj = null;
+        int res = 0;
+
+        if (cond) {
+            obj = obj1;
+        } else {
+            obj = obj2;
+        }
+
+        for (int i=1; i<132; i++) {
+            res += obj.x;
+        }
+
+        return res + obj1.x + obj2.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be removed. After initialization they are read-only objects.
+    // Access to the input of the merge, after the merge, is fine.
+    int testPollutedNoWrite_C2(boolean cond, int l) { return testPollutedNoWrite(cond, l); }
+
+    @DontCompile
+    int testPollutedNoWrite_Interp(boolean cond, int l) { return testPollutedNoWrite(cond, l); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testThreeWayAliasedAlloc(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+        Point p3 = new Point(x+2, y+2);
+
+        if (cond) {
+            p3 = p1;
+        } else {
+            p3 = p2;
+        }
+
+        return p3.x + p3.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Initial p3 will always be dead.
+    // The other two allocations will be reduced and scaled
+    int testThreeWayAliasedAlloc_C2(boolean cond, int x, int y) { return testThreeWayAliasedAlloc(cond, x, y); }
+
+    @DontCompile
+    int testThreeWayAliasedAlloc_Interp(boolean cond, int x, int y) { return testThreeWayAliasedAlloc(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int TestTrapAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, x);
+
+        if (cond) {
+            p = new Point(y, y);
+        }
+
+        for (int i=402; i<432; i+=x) {
+            x++;
+        }
+
+        return p.x + x;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be eliminated.
+    int TestTrapAfterMerge_C2(boolean cond, int x, int y) { return TestTrapAfterMerge(cond, x, y); }
+
+    @DontCompile
+    int TestTrapAfterMerge_Interp(boolean cond, int x, int y) { return TestTrapAfterMerge(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    Point testNestedObjectsObject(boolean cond, int x, int y) {
+        Picture p = new Picture(x, x, y);
+
+        if (cond) {
+            p = new Picture(y, y, x);
+        }
+
+        return p.position;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" })
+    // The allocation of "Picture" will be removed and only allocations of "Position" will be kept
+    Point testNestedObjectsObject_C2(boolean cond, int x, int y) { return testNestedObjectsObject(cond, x, y); }
+
+    @DontCompile
+    Point testNestedObjectsObject_Interp(boolean cond, int x, int y) { return testNestedObjectsObject(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testNestedObjectsNoEscapeObject(boolean cond, int x, int y) {
+        Picture p = new Picture(x, x, y);
+
+        if (cond) {
+            p = new Picture(y, y, x);
+        }
+
+        return p.position.x;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" } )
+    // The two Picture objects will be removed. The nested Point objects won't
+    // be removed because the Phi merging them will have a DecodeN user - which
+    // currently isn't supported.
+    int testNestedObjectsNoEscapeObject_C2(boolean cond, int x, int y) { return testNestedObjectsNoEscapeObject(cond, x, y); }
+
+    @DontCompile
+    int testNestedObjectsNoEscapeObject_Interp(boolean cond, int x, int y) { return testNestedObjectsNoEscapeObject(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    Point[] testNestedObjectsArray(boolean cond, int x, int y) {
+        PicturePositions p = new PicturePositions(x, y, x+y);
+
+        if (cond) {
+            p = new PicturePositions(x+1, y+1, x+y+1);
+        }
+
+        return p.positions;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "4" })
+    // The two PicturePositions objects will be reduced and scaled.
+    Point[] testNestedObjectsArray_C2(boolean cond, int x, int y) { return testNestedObjectsArray(cond, x, y); }
+
+    @DontCompile
+    Point[] testNestedObjectsArray_Interp(boolean cond, int x, int y) { return testNestedObjectsArray(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testTrappingAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond) {
+            p = new Point(y, y);
+        }
+
+        for (int i=832; i<932; i++) {
+            res += p.x;
+        }
+
+        if (x > y) {
+            res += new Point(p.x, p.y).x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // The allocation inside the last if will be removed because it's not part of a merge
+    // The other two allocations will be reduced and removed
+    int testTrappingAfterMerge_C2(boolean cond, int x, int y) { return testTrappingAfterMerge(cond, x, y); }
+
+    @DontCompile
+    int testTrappingAfterMerge_Interp(boolean cond, int x, int y) { return testTrappingAfterMerge(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSimpleAliasedAlloc(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(y, x);
+        Point p = p1;
+
+        if (cond) {
+            p = p2;
+        }
+
+        return p.x * p.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both merges will be reduced and removed
+    int testSimpleAliasedAlloc_C2(boolean cond, int x, int y) { return testSimpleAliasedAlloc(cond, x, y); }
+
+    @DontCompile
+    int testSimpleAliasedAlloc_Interp(boolean cond, int x, int y) { return testSimpleAliasedAlloc(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSimpleDoubleMerge(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+
+        if (cond) {
+            p1 = new Point(y, x);
+            p2 = new Point(y+1, x+1);
+        }
+
+        return p1.x + p2.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both merges will be reduced and removed
+    int testSimpleDoubleMerge_C2(boolean cond, int x, int y) { return testSimpleDoubleMerge(cond, x, y); }
+
+    @DontCompile
+    int testSimpleDoubleMerge_Interp(boolean cond, int x, int y) { return testSimpleDoubleMerge(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testConsecutiveSimpleMerge(boolean cond1, boolean cond2, int x, int y) {
+        Point p0 = new Point(x, x);
+        Point p1 = new Point(x, y);
+        Point pA = null;
+
+        Point p2 = new Point(y, x);
+        Point p3 = new Point(y, y);
+        Point pB = null;
+
+        if (cond1) {
+            pA = p0;
+        } else {
+            pA = p1;
+        }
+
+        if (cond2) {
+            pB = p2;
+        } else {
+            pB = p3;
+        }
+
+        return pA.x * pA.y + pB.x * pB.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // All allocations will be removed.
+    int testConsecutiveSimpleMerge_C2(boolean cond1, boolean cond2, int x, int y) { return testConsecutiveSimpleMerge(cond1, cond2, x, y); }
+
+    @DontCompile
+    int testConsecutiveSimpleMerge_Interp(boolean cond1, boolean cond2, int x, int y) { return testConsecutiveSimpleMerge(cond1, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testDoubleIfElseMerge(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+1, y+1);
+
+        if (cond) {
+            p1 = new Point(y, x);
+            p2 = new Point(y, x);
+        } else {
+            p1 = new Point(x, y);
+            p2 = new Point(x+1, y+1);
+        }
+
+        return p1.x * p2.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // The initial allocation is always dead. The other
+    // two will be reduced and scaled.
+    int testDoubleIfElseMerge_C2(boolean cond, int x, int y) { return testDoubleIfElseMerge(cond, x, y); }
+
+    @DontCompile
+    int testDoubleIfElseMerge_Interp(boolean cond, int x, int y) { return testDoubleIfElseMerge(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testNoEscapeWithLoadInLoop(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+        int res = 0;
+
+        if (cond) {
+            p = new Point(y, x);
+        }
+
+        for (int i=3342; i<4234; i++) {
+            res += p.x + p.y + i;
+        }
+
+        return res + p.x + p.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be reduced and scaled.
+    int testNoEscapeWithLoadInLoop_C2(boolean cond, int x, int y) { return testNoEscapeWithLoadInLoop(cond, x, y); }
+
+    @DontCompile
+    int testNoEscapeWithLoadInLoop_Interp(boolean cond, int x, int y) { return testNoEscapeWithLoadInLoop(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCmpAfterMerge(boolean cond, boolean cond2, int x, int y) {
+        Point a = new Point(x, y);
+        Point b = new Point(y, x);
+        Point c = null;
+
+        if (x+2 >= y-5) {
+            c = a;
+        } else {
+            c = b;
+        }
+
+        return cond2 ? c.x : c.y;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be reduced and scaled
+    int testCmpAfterMerge_C2(boolean cond, boolean cond2, int x, int y) { return testCmpAfterMerge(cond, cond2, x, y); }
+
+    @DontCompile
+    int testCmpAfterMerge_Interp(boolean cond, boolean cond2, int x, int y) { return testCmpAfterMerge(cond, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCondAfterMergeWithAllocate(boolean cond1, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1) {
+            p = new Point(y, x);
+        }
+
+        if (cond2 && cond1) {
+            return p.x;
+        } else {
+            return 321;
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be eliminated.
+    int testCondAfterMergeWithAllocate_C2(boolean cond1, boolean cond2, int x, int y) { return testCondAfterMergeWithAllocate(cond1, cond2, x, y); }
+
+    @DontCompile
+    int testCondAfterMergeWithAllocate_Interp(boolean cond1, boolean cond2, int x, int y) { return testCondAfterMergeWithAllocate(cond1, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testCondLoadAfterMerge(boolean cond1, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1) {
+            p = new Point(y, x);
+        }
+
+        if (cond1 == false && cond2 == false) {
+            return p.x + 1;
+        } else if (cond1 == false && cond2 == true) {
+            return p.x + 30;
+        } else if (cond1 == true && cond2 == false) {
+            return p.x + 40;
+        } else if (cond1 == true && cond2 == true) {
+            return p.x + 50;
+        } else {
+            return -1;
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be eliminated.
+    int testCondLoadAfterMerge_C2(boolean cond1, boolean cond2, int x, int y) { return testCondLoadAfterMerge(cond1, cond2, x, y); }
+
+    @DontCompile
+    int testCondLoadAfterMerge_Interp(boolean cond1, boolean cond2, int x, int y) { return testCondLoadAfterMerge(cond1, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testIfElseInLoop() {
+        int res = 0;
+
+        for (int i=1; i<1000; i++) {
+            Point obj = new Point(i, i);
+
+            if (i % 2 == 1) {
+                obj = new Point(i, i+1);
+            } else {
+                obj = new Point(i-1, i);
+            }
+
+            res += obj.x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // The initial allocation is always dead. The other
+    // two will be reduced and scaled.
+    int testIfElseInLoop_C2() { return testIfElseInLoop(); }
+
+    @DontCompile
+    int testIfElseInLoop_Interp() { return testIfElseInLoop(); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testLoadInCondAfterMerge(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond) {
+            p = new Point(y, x);
+        }
+
+        if (p.x == 10) {
+            if (p.y == 10) {
+                return dummy(10);
+            } else {
+                return dummy(20);
+            }
+        } else if (p.x == 20) {
+            if (p.y == 20) {
+                return dummy(30);
+            } else {
+                return dummy(40);
+            }
+        }
+
+        return 1984;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be reduced and removed.
+    int testLoadInCondAfterMerge_C2(boolean cond, int x, int y) { return testLoadInCondAfterMerge(cond, x, y); }
+
+    @DontCompile
+    int testLoadInCondAfterMerge_Interp(boolean cond, int x, int y) { return testLoadInCondAfterMerge(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testLoadInLoop(boolean cond, int x, int y) {
+        Point obj1 = new Point(x, y);
+        Point obj2 = new Point(y, x);
+        Point obj = null;
+        int res = 0;
+
+        if (cond) {
+            obj = obj1;
+        } else {
+            obj = obj2;
+        }
+
+        for (int i = 0; i < 532; i++) {
+            res += obj.x;
+        }
+
+        return res;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    // Both allocations will be reduced and removed.
+    int testLoadInLoop_C2(boolean cond, int x, int y) { return testLoadInLoop(cond, x, y); }
+
+    @DontCompile
+    int testLoadInLoop_Interp(boolean cond, int x, int y) { return testLoadInLoop(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testMergesAndMixedEscape(boolean cond, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x, y);
+        int val  = 0;
+
+        if (cond) {
+            p1 = new Point(x+1, y+1);
+            val = dummy(p2);
+        }
+
+        return val + p1.x + p2.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "1" })
+    // p2 escapes and will remain. The other two allocations will be reduced and scaled.
+    int testMergesAndMixedEscape_C2(boolean cond, int x, int y) { return testMergesAndMixedEscape(cond, x, y); }
+
+    @DontCompile
+    int testMergesAndMixedEscape_Interp(boolean cond, int x, int y) { return testMergesAndMixedEscape(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSRAndNSR_NoTrap(boolean cond1, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1) {
+            p = new Point(x+1, y+1);
+            global_escape = p;
+        }
+
+        return p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "<=1" })
+    int testSRAndNSR_NoTrap_C2(boolean cond1, int x, int y) { return testSRAndNSR_NoTrap(cond1, x, y); }
+
+    @DontCompile
+    int testSRAndNSR_NoTrap_Interp(boolean cond1, int x, int y) { return testSRAndNSR_NoTrap(cond1, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testSRAndNSR_Trap(boolean is_c2, boolean cond1, boolean cond2, int x, int y) {
+        Point p = new Point(x, y);
+
+        if (cond1) {
+            p = new Point(x+1, y+1);
+            global_escape = p;
+        }
+
+        int res = p.x;
+        if (is_c2) {
+            // This will show up to C2 as a trap.
+            dummy_defaults();
+        }
+
+        return res;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "<=1" })
+    int testSRAndNSR_Trap_C2(boolean is_c2, boolean cond1, boolean cond2, int x, int y) { return testSRAndNSR_Trap(is_c2, cond1, cond2, x, y); }
+
+    @DontCompile
+    int testSRAndNSR_Trap_Interp(boolean is_c2, boolean cond1, boolean cond2, int x, int y) { return testSRAndNSR_Trap(is_c2, cond1, cond2, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    char testString_one(boolean cond1) {
+        String p = new String("Java");
+
+        if (cond1) {
+            p = new String("HotSpot");
+        }
+
+        return p.charAt(0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "0" })
+    char testString_one_C2(boolean cond1) { return testString_one(cond1); }
+
+    @DontCompile
+    char testString_one_Interp(boolean cond1) { return testString_one(cond1); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    char testString_two(boolean cond1) {
+        String p = new String("HotSpot");
+
+        if (cond1) {
+            p = dummy("String");
+            if (p == null) return 'J';
+        }
+
+        return p.charAt(0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "0" })
+    char testString_two_C2(boolean cond1) { return testString_two(cond1); }
+
+    @DontCompile
+    char testString_two_Interp(boolean cond1) { return testString_two(cond1); }
+
+    // ------------------ Utility for Testing ------------------- //
+
+    @DontCompile
+    static void dummy() {
+    }
+
+    @DontCompile
+    static int dummy(Point p) {
+        return p.x * p.y;
+    }
+
+    @DontCompile
+    static int dummy(int x) {
+        return x;
+    }
+
+    @DontCompile
+    static Point dummy(int x, int y) {
+        return new Point(x, y);
+    }
+
+    @DontCompile
+    static String dummy(String str) {
+        return str;
+    }
+
+    @DontCompile
+    static ADefaults dummy_defaults() {
+        return new ADefaults();
+    }
+
+    static class Point {
+        int x, y;
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (!(o instanceof Point)) return false;
+            Point p = (Point) o;
+            return (p.x == x) && (p.y == y);
+        }
+    }
+
+    class Shape {
+        int x, y, l;
+        Shape(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    class Square extends Shape {
+        Square(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    class Circle extends Shape {
+        Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ADefaults {
+        static int ble;
+        int i;
+        @DontCompile
+        ADefaults(int i) { this.i = i; }
+        @DontCompile
+        ADefaults() { }
+    }
+
+    static class Picture {
+        public int id;
+        public Point position;
+
+        public Picture(int id, int x, int y) {
+            this.id = id;
+            this.position = new Point(x, y);
+        }
+    }
+
+    static class PicturePositions {
+        public int id;
+        public Point[] positions;
+
+        public PicturePositions(int id, int x, int y) {
+            this.id = id;
+            this.positions = new Point[] { new Point(x, y), new Point(y, x) };
+        }
+    }
+
+    class Root {
+        public int a;
+        public int b;
+        public int c;
+        public int d;
+        public int e;
+
+        public Root(int a, int b, int c, int d, int e) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+        }
+    }
+
+    class Usr extends Root {
+        public float flt;
+
+        public Usr(float a, float b, float c) {
+            super((int)a, (int)b, (int)c, 0, 0);
+            this.flt = a;
+        }
+    }
+
+    class Home extends Root {
+        public double[] arr;
+
+        public Home(double a, double b) {
+            super((int)a, (int)b, 0, 0, 0);
+            this.arr = new double[] {a, b};
+        }
+
+    }
+
+    class Tmp extends Root {
+        public String s;
+
+        public Tmp(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.s = s;
+        }
+    }
+
+    class Etc extends Root {
+        public String a;
+
+        public Etc(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.a = s;
+        }
+    }
+
+    class A { }
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+}


### PR DESCRIPTION
This is the backport of these two PRs:
- https://github.com/openjdk/jdk/pull/12897
- https://github.com/openjdk/jdk/pull/14976

This Pull Request *should not* be merged. It was created just to make it easier to review the changes. Once approved, I'll move the `cesar/ramjdk21` branch into `ms-patches\reduce-allocation-merges`.