### PR TITLE
Updates to catch up with Tip

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -470,7 +470,7 @@
   develop(bool, TracePostallocExpand, false, "Trace expanding nodes after"  \
           " register allocation.")                                          \
                                                                             \
-  product(bool, ReduceAllocationMerges, true, DIAGNOSTIC,                   \
+  product(bool, ReduceAllocationMerges, true,                               \
           "Try to simplify allocation merges before Scalar Replacement")    \
                                                                             \
   notproduct(bool, TraceReduceAllocationMerges, false,                      \


### PR DESCRIPTION
This PR removes the "DIAGNOSTIC" label of the ReduceAllocationMerges to make consistent how we disable the optimization across our JDK builds.