### PR TITLE
UnsafeIntrinsicsTest.java#ZGenerationalDebug assert(!assert_on_failure) failed: Has low-order bits set

### DIFF
--- a/ms-patches/backport-8334475.yml
+++ b/ms-patches/backport-8334475.yml
@@ -1,0 +1,10 @@
+title: UnsafeIntrinsicsTest.java#ZGenerationalDebug assert(!assert_on_failure) failed: Has low-order bits set
+- work_item: 2224939
+- jbs_bug: JDK-8334475
+- author: swesonga
+- owner: swesonga
+- contributors:
+- details:
+  - Backport of https://github.com/openjdk/jdk/pull/20390
+- release_note:
+  - Fixes assertion failure in Windows AArch64 code triggered by ZGC test.

--- a/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
@@ -26,7 +26,26 @@
 #ifndef OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_HPP
 #define OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_HPP
 
+#include "runtime/atomic.hpp"
+
 #include <string.h>
+
+template <typename T>
+static void pd_conjoint_atomic_helper(const T* from, T* to, size_t count) {
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      Atomic::store(to++, Atomic::load(from++));
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      Atomic::store(to--, Atomic::load(from--));
+    }
+  }
+}
 
 static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
   (void)memmove(to, from, count * HeapWordSize);
@@ -71,55 +90,19 @@ static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
 }
 
 static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
-  if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
-  if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
-  pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
- if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+ pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {


### PR DESCRIPTION
Backports the fix for https://bugs.openjdk.org/browse/JDK-8334475