### PR TITLE
Add patch for Windows AArch64 atomic jlong copying

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -18,6 +18,7 @@ active-patches:
 # - ms-patches/microsoft-patch-index // this patch branch is required for all releases
   - ms-patches/reduce-allocation-merges
   - ms-patches/8317562-jfr-compiler-queues
+  - ms-patches/8334475-fix-jlong-copy
   - ms-patches/use-all-windows-processor-groups
   - ms-patches/gettemppath2
 


### PR DESCRIPTION
The patch will be added by https://github.com/microsoft/openjdk-jdk21u/pull/18