### PR TITLE
Remove backport for 65+ processor support from active patch list

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -19,7 +19,6 @@ active-patches:
   - ms-patches/reduce-allocation-merges
   - ms-patches/8317562-jfr-compiler-queues
   - ms-patches/8334475-fix-jlong-copy
-  - ms-patches/use-all-windows-processor-groups
   - ms-patches/gettemppath2
   - ms-patches/remove_undocumentedAPI
 

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -31,6 +31,7 @@ active-patches:
   # - ZZ_archive/ms-patches/feature-branch-name-1
   # ...
   # - ZZ_archive/ms-patches/feature-branch-name-N
+  # - ms-patches/use-all-windows-processor-groups
 
 
 # Patches that we are no longer applying to our releases as they have


### PR DESCRIPTION
65+ processor support was backported to jdk21 upstream in https://github.com/openjdk/jdk21u-dev/commit/5be5942de233727b261b847340441bc6c98b17ce and is no longer needed in our ms-patches system. This prevents merge conflicts when applying the patch to the latest jdk21u-dev repo.