### PR TITLE
Remove backport of JDK-8334475 fix from jdk21u active patch list

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -18,7 +18,6 @@ active-patches:
 # - ms-patches/microsoft-patch-index // this patch branch is required for all releases
   - ms-patches/reduce-allocation-merges
   - ms-patches/8317562-jfr-compiler-queues
-  - ms-patches/8334475-fix-jlong-copy
   - ms-patches/gettemppath2
   - ms-patches/remove_undocumentedAPI
 
@@ -31,6 +30,7 @@ active-patches:
   # - ZZ_archive/ms-patches/feature-branch-name-1
   # ...
   # - ZZ_archive/ms-patches/feature-branch-name-N
+  # - ZZ_archive/ms-patches/8334475-fix-jlong-copy
   # - ZZ_archive/ms-patches/use-all-windows-processor-groups
 
 


### PR DESCRIPTION
The backport was completed in https://github.com/openjdk/jdk21u-dev/commit/046c4aa16167134d1614be81a375d2d86e44077a

I will rename the branch to match the ZZ_archive format after this PR is merged.