### PR TITLE
Enable High-Performance GPU Selection for Windows in JVM

### DIFF
--- a/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
+++ b/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
@@ -1,0 +1,8 @@
+title: Enable High-Performance GPU Selection for Windows in JVM
+- work_item: '1949141'
+- author: mo-beck
+- owner: mo-beck
+- details:
+  - Exported driver hints to prefer high-performance GPU (NVIDIA/AMD) from the JVM
+  - Useful in environments like Minecraft, IDEs, or ML tooling to ensure GPU utilization
+- release_note: ''Enabled GPU selection hinting in Windows builds using NvOptimusEnablement and AmdPowerXpressRequestHighPerformance''

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -110,6 +110,21 @@
 #include <winsock2.h>
 #include <versionhelpers.h>
 
+// Export symbols to request high-performance GPU usage on Windows.
+// These variables are picked up by NVIDIA and AMD drivers to trigger
+// usage of the discrete GPU (if available).
+extern "C" {
+  __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+  __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
+// Log GPU export during startup for trace-level diagnostics
+static struct GPUExportLogger {
+  GPUExportLogger() {
+    log_trace(os)("JVM GPU Selection: Exporting NvOptimusEnablement and AmdPowerXpressRequestHighPerformance hints for driver.");
+  }
+} gpu_export_logger;
+
 // for timer info max values which include all bits
 #define ALL_64_BITS CONST64(-1)
 


### PR DESCRIPTION
**Work Item**: `1949141`  
**Metadata file**: `ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml`  

### Summary
This patch exports two vendor-specific variables during JVM startup on Windows to hint GPU drivers to favor discrete GPUs (when available):
- `NvOptimusEnablement` for NVIDIA
- `AmdPowerXpressRequestHighPerformance` for AMD

### Motivation 
Improves performance in scenarios where discrete GPU usage is beneficial, including:
- Games (e.g., Minecraft)
- Machine learning tools
- IDEs or GUI-intensive applications