### PR TITLE
Add GPU selection patch to Microsoft patch index

### DIFF
--- a/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
+++ b/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
@@ -1,0 +1,8 @@
+title: Enable High-Performance GPU Selection for Windows in JVM
+- work_item: '1949141'
+- author: mo-beck
+- owner: mo-beck
+- details:
+  - Exported driver hints to prefer high-performance GPU (NVIDIA/AMD) from the JVM
+  - Useful in environments like Minecraft, IDEs, or ML tooling to ensure GPU utilization
+- release_note: ''Enabled GPU selection hinting in Windows builds using NvOptimusEnablement and AmdPowerXpressRequestHighPerformance''

--- a/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
+++ b/ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm.yml
@@ -1,8 +1,0 @@
-title: Enable High-Performance GPU Selection for Windows in JVM
-- work_item: '1949141'
-- author: mo-beck
-- owner: mo-beck
-- details:
-  - Exported driver hints to prefer high-performance GPU (NVIDIA/AMD) from the JVM
-  - Useful in environments like Minecraft, IDEs, or ML tooling to ensure GPU utilization
-- release_note: ''Enabled GPU selection hinting in Windows builds using NvOptimusEnablement and AmdPowerXpressRequestHighPerformance''

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -23,6 +23,7 @@ active-patches:
   - ms-patches/remove_undocumentedAPI
   - ms-patches/8345296-aarch64-prctl
   - ms-patches/cleanup-unknown-unwind-opcodes
+  - ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm
 
 
 ## Upstreamed Patches


### PR DESCRIPTION
This PR adds `ms-patches/enable-high-performance-gpu-selection-for-windows-in-jvm` to the list of active patches in `ms-patches/microsoft-patch-index.yml`.

Associated patch PR: https://github.com/microsoft/openjdk-jdk21u/pull/32

This ensures the patch will be included in future release builds.
