### PR TITLE
Backporting safe index update from tip

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -476,13 +476,13 @@ static u2 utf8_info_index(const InstanceKlass* ik, const Symbol* const target, T
   assert(target != nullptr, "invariant");
   const ConstantPool* cp = ik->constants();
   const int cp_len = cp->length();
-  for (u2 index = 1; index < cp_len; ++index) {
+  for (int index = 1; index < cp_len; ++index) {
     const constantTag tag = cp->tag_at(index);
     if (tag.is_utf8()) {
       const Symbol* const utf8_sym = cp->symbol_at(index);
       assert(utf8_sym != nullptr, "invariant");
       if (utf8_sym == target) {
-        return index;
+        return static_cast<u2>(index);
       }
     }
   }


### PR DESCRIPTION
Comparisons between types of different widths in a loop condition can cause the loop to behave unexpectedly. Here, there could potentially be an infinite loop (if cp_len > 65535)

Link to update in tip: https://github.com/openjdk/jdk/blob/431f46724658b703e995e518cb7a2149c50d6a9d/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp#L288C2-L299C27