### PR TITLE
Do not modify r18_tls when restoring registers on Windows AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -301,11 +301,11 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef _WINDOWS
+#ifdef R18_RESERVED
   /*
-  Do not modify r18_tls when restoring registers on Windows as it is used to
-  store the pointer to the current thread's TEB (where TLS variables are stored).
-  See r18_tls comment in register_aarch64.hpp.
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
   */
   __ pop(RegSet::range(r0, r17), sp);
   __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
@@ -325,11 +325,11 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
-#ifdef _WINDOWS
+#ifdef R18_RESERVED
   /*
-  Do not modify r18_tls when restoring registers on Windows as it is used to
-  store the pointer to the current thread's TEB (where TLS variables are stored).
-  See r18_tls comment in register_aarch64.hpp.
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
   */
   __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
   __ pop(RegSet::range(r2, r17), sp);

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -301,7 +301,18 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef _WINDOWS
+  /*
+  Do not modify r18_tls when restoring registers on Windows as it is used to
+  store the pointer to the current thread's TEB (where TLS variables are stored).
+  See r18_tls comment in register_aarch64.hpp.
+  */
+  __ pop(RegSet::range(r0, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ pop(RegSet::range(r0, r29), sp);
+#endif
 }
 
 static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_fpu_registers = true)  {
@@ -314,8 +325,20 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef _WINDOWS
+  /*
+  Do not modify r18_tls when restoring registers on Windows as it is used to
+  store the pointer to the current thread's TEB (where TLS variables are stored).
+  See r18_tls comment in register_aarch64.hpp.
+  */
+  __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r2, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ ldp(zr, r1, Address(__ post(sp, 16)));
   __ pop(RegSet::range(r2, r29), sp);
+#endif
 }
 
 


### PR DESCRIPTION
On Windows, r18_tls is used store the pointer to the current thread's TEB. Therefore, this register should never be modified (see details in [register_aarch64.hpp](https://github.com/openjdk/jdk21u/blob/jdk-21.0.9-ga/src/hotspot/cpu/aarch64/register_aarch64.hpp#L117-L126)). This issue was identified when investigating hangs and crashes in the virtual threads on the Windows AArch64 jdk25u build. See https://github.com/microsoft/openjdk-jdk25u/pull/19 for details.