### PR TITLE
Restore exception handling changes with safefetch fix

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2729,6 +2729,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     // Verify that OS save/restore AVX registers.
     return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr());
   }
+#elif defined(_M_ARM64)
+  if (handle_safefetch(exception_code, pc, (void*)exceptionInfo->ContextRecord)) {
+    return EXCEPTION_CONTINUE_EXECUTION;
+  }
 #endif
 
   if (t != nullptr && t->is_Java_thread()) {
@@ -2761,10 +2765,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         overflow_state->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
         report_error(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
-#endif
         return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
@@ -2820,10 +2822,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 #endif
 
       // Stack overflow or null pointer exception in native code.
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
       report_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
-#endif
       return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2897,41 +2897,21 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
   }
 
-#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
-  if (exception_code != EXCEPTION_BREAKPOINT) {
+  bool should_report_error = (exception_code != EXCEPTION_BREAKPOINT);
+
+#if defined(_M_ARM64)
+  should_report_error = should_report_error &&
+                        FAILED(exception_code) &&
+                        (exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION);
+#endif
+
+  if (should_report_error) {
     report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
-#endif
-  return EXCEPTION_CONTINUE_SEARCH;
-}
-
-#if defined(USE_VECTORED_EXCEPTION_HANDLING)
-LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-#if defined(_M_ARM64)
-  address pc = (address) exceptionInfo->ContextRecord->Pc;
-#elif defined(_M_AMD64)
-  address pc = (address) exceptionInfo->ContextRecord->Rip;
-#else
-  address pc = (address) exceptionInfo->ContextRecord->Eip;
-#endif
-
-  // Fast path for code part of the code cache
-  if (CodeCache::low_bound() <= pc && pc < CodeCache::high_bound()) {
-    return topLevelExceptionFilter(exceptionInfo);
-  }
-
-  // If the exception occurred in the codeCache, pass control
-  // to our normal exception handler.
-  CodeBlob* cb = CodeCache::find_blob(pc);
-  if (cb != nullptr) {
-    return topLevelExceptionFilter(exceptionInfo);
-  }
 
   return EXCEPTION_CONTINUE_SEARCH;
 }
-#endif
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
@@ -4657,7 +4637,7 @@ jint os::init_2(void) {
   // Setup Windows Exceptions
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
-  topLevelVectoredExceptionHandler = AddVectoredExceptionHandler(1, topLevelVectoredExceptionFilter);
+  topLevelVectoredExceptionHandler = AddVectoredExceptionHandler(1, topLevelExceptionFilter);
   previousUnhandledExceptionFilter = SetUnhandledExceptionFilter(topLevelUnhandledExceptionFilter);
 #endif
 

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -172,6 +172,8 @@ public:
   // signal support
   static void* install_signal_handler(int sig, signal_handler_t handler);
   static void* user_handler();
+
+  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 #endif // OS_WINDOWS_OS_WINDOWS_HPP

--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+
+#include "precompiled.hpp"
+#include "os_windows.hpp"
+#include "runtime/os.hpp"
+#include "runtime/safefetch.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+#ifdef SAFEFETCH_METHOD_STATIC_ASSEMBLY
+
+// SafeFetch handling, static assembly style:
+//
+// SafeFetch32 and SafeFetchN are implemented via static assembly
+// and live in os_cpu/xx_xx/safefetch_xx_xx.S
+
+extern "C" char _SafeFetch32_continuation[];
+extern "C" char _SafeFetch32_fault[];
+
+#ifdef _LP64
+extern "C" char _SafeFetchN_continuation[];
+extern "C" char _SafeFetchN_fault[];
+#endif // _LP64
+
+bool handle_safefetch(int exception_code, address pc, void* context) {
+  CONTEXT* ctx = (CONTEXT*)context;
+  if (exception_code == EXCEPTION_ACCESS_VIOLATION && ctx != nullptr) {
+    if (pc == (address)_SafeFetch32_fault) {
+      os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
+      return true;
+    }
+#ifdef _LP64
+    if (pc == (address)_SafeFetchN_fault) {
+      os::win32::context_set_pc(ctx, (address)_SafeFetchN_continuation);
+      return true;
+    }
+#endif
+  }
+  return false;
+}
+
+#endif // SAFEFETCH_METHOD_STATIC_ASSEMBLY

--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -47,7 +47,8 @@ extern "C" char _SafeFetchN_fault[];
 
 bool handle_safefetch(int exception_code, address pc, void* context) {
   CONTEXT* ctx = (CONTEXT*)context;
-  if (exception_code == EXCEPTION_ACCESS_VIOLATION && ctx != nullptr) {
+  if ((exception_code == EXCEPTION_ACCESS_VIOLATION ||
+       exception_code == EXCEPTION_GUARD_PAGE) && ctx != nullptr) {
     if (pc == (address)_SafeFetch32_fault) {
       os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
       return true;

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -99,6 +99,10 @@ frame os::fetch_frame_from_context(const void* ucVoid) {
   return frame(sp, fp, epc);
 }
 
+void os::win32::context_set_pc(CONTEXT* uc, address pc) {
+  uc->Pc = (intptr_t)pc;
+}
+
 bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
         struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
   PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;

--- a/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
@@ -1,0 +1,65 @@
+;
+; Copyright (c) 2022 SAP SE. All rights reserved.
+; Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int SafeFetch32(int* address, int defaultval);
+    ;
+    ;  x0 : address
+    ;  w1 : defaultval
+
+    ; needed to align function start to 4 byte
+    ALIGN  4
+    EXPORT _SafeFetch32_fault
+    EXPORT _SafeFetch32_continuation
+    EXPORT SafeFetch32_impl
+    AREA safefetch_text, CODE
+
+SafeFetch32_impl
+_SafeFetch32_fault
+    ldr w0, [x0]
+    ret
+
+_SafeFetch32_continuation
+    mov      x0, x1
+    ret
+
+    ; Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    ;
+    ;  x0 : address
+    ;  x1 : defaultval
+
+    ALIGN  4
+    EXPORT _SafeFetchN_fault
+    EXPORT _SafeFetchN_continuation
+    EXPORT SafeFetchN_impl
+
+SafeFetchN_impl
+_SafeFetchN_fault
+    ldr      x0, [x0]
+    ret
+
+_SafeFetchN_continuation
+    mov      x0, x1
+    ret
+
+    END

--- a/src/hotspot/share/runtime/safefetch.hpp
+++ b/src/hotspot/share/runtime/safefetch.hpp
@@ -31,7 +31,7 @@
 // Safefetch allows to load a value from a location that's not known
 // to be valid. If the load causes a fault, the error value is returned.
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_M_ARM64)
   // Windows uses Structured Exception Handling
   #include "safefetch_windows.hpp"
 #elif defined(ZERO) || defined (_AIX)

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -29,6 +29,8 @@
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/os.hpp"
+#include "runtime/safefetch.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "concurrentTestRunner.inline.hpp"
 #include "unittest.hpp"
 
@@ -841,6 +843,62 @@ TEST_VM(os_windows, reserve_memory_special_concurrent) {
   ReserveMemorySpecialRunnable runnable;
   ConcurrentTestRunner testRunner(&runnable, 30, 15000);
   testRunner.run();
+}
+
+// Test that SafeFetch correctly returns the error value when reading
+// from a page with PAGE_GUARD protection on Windows.
+// PAGE_GUARD raises STATUS_GUARD_PAGE_VIOLATION which is distinct from
+// EXCEPTION_ACCESS_VIOLATION. SafeFetch must handle both.
+TEST_VM(os_windows, safefetch_page_guard) {
+  const DWORD page_size = (DWORD)os::vm_page_size();
+
+  // Allocate a committed read-write page.
+  void* mem = ::VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  ASSERT_NE(mem, nullptr) << "VirtualAlloc failed";
+
+  // Write known patterns into the page.
+  static const intptr_t patternN = LP64_ONLY(0xABCDDEADBEEFABCDULL) NOT_LP64(0xDEADBEEF);
+  static const int pattern32 = (int)0xDEADBEEF;
+  intptr_t* addrN = (intptr_t*)mem;
+  int*      addr32 = (int*)mem;
+  *addrN = patternN;
+  // Place the 32-bit pattern right after the intptr_t value.
+  *(int*)((char*)mem + sizeof(intptr_t)) = pattern32;
+  addr32 = (int*)((char*)mem + sizeof(intptr_t));
+
+  // Sanity: SafeFetch should read the values before we guard the page.
+  ASSERT_EQ(patternN, SafeFetchN(addrN, 0));
+  ASSERT_EQ((uint64_t)pattern32, (uint64_t)SafeFetch32(addr32, 0));
+
+  // Now set PAGE_GUARD on the page. The next access will raise
+  // STATUS_GUARD_PAGE_VIOLATION (one-shot semantics).
+  DWORD old_protect;
+  BOOL ok = ::VirtualProtect(mem, page_size, PAGE_READWRITE | PAGE_GUARD, &old_protect);
+  ASSERT_TRUE(ok) << "VirtualProtect PAGE_GUARD failed";
+
+  // SafeFetchN: should return the error value, not the page contents.
+  intptr_t resultN = SafeFetchN(addrN, -1);
+  ASSERT_EQ((intptr_t)-1, resultN)
+      << "SafeFetchN should return errValue for PAGE_GUARD page";
+
+  // Re-arm the guard (it was consumed by the previous fault).
+  ok = ::VirtualProtect(mem, page_size, PAGE_READWRITE | PAGE_GUARD, &old_protect);
+  ASSERT_TRUE(ok) << "VirtualProtect PAGE_GUARD re-arm failed";
+
+  // SafeFetch32: should also return the error value.
+  int result32 = SafeFetch32(addr32, -1);
+  ASSERT_EQ(-1, result32)
+      << "SafeFetch32 should return errValue for PAGE_GUARD page";
+
+  // Re-arm the guard one more time to test with a different error value.
+  ok = ::VirtualProtect(mem, page_size, PAGE_READWRITE | PAGE_GUARD, &old_protect);
+  ASSERT_TRUE(ok) << "VirtualProtect PAGE_GUARD re-arm failed";
+
+  intptr_t resultN2 = SafeFetchN(addrN, ~patternN);
+  ASSERT_EQ(~patternN, resultN2)
+      << "SafeFetchN should return the exact errValue passed";
+
+  ::VirtualFree(mem, 0, MEM_RELEASE);
 }
 
 #endif

--- a/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
@@ -64,7 +64,7 @@ public class UncaughtNativeExceptionTest {
         assertTrue(Files.exists(hsErrPath));
 
         Pattern[] positivePatterns = {
-            Pattern.compile(".*Internal Error \\(0x2a\\).*")
+            Pattern.compile(".*Internal Error \\(0xdeadbeef\\).*")
         };
         HsErrFileUtils.checkHsErrFileContent(hsErrFile, positivePatterns, null, true /* check end marker */, false /* verbose */);
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libNativeException.c
@@ -25,7 +25,8 @@
 
 #include <Windows.h>
 
-const DWORD EX_CODE = 42;
+// Use an exception code that causes the FAILED() macro to return true.
+const DWORD EX_CODE = 0xdeadbeef;
 
 JNIEXPORT void JNICALL Java_UncaughtNativeExceptionTest_00024Crasher_throwException(JNIEnv* env, jclass cls) {
   RaiseException(EX_CODE, EXCEPTION_NONCONTINUABLE, 0, NULL);


### PR DESCRIPTION
We reverted the exception handling changes (enabling core dump creation) in jdk21u due to an EXCEPTION_GUARD_PAGE that we have now traced to the safefetch implementation. This change restores core dump creation and handles guard page exceptions.