### PR TITLE
Mark Reserved Stack Area as unsupported on Windows/ARM64

### DIFF
--- a/ms-patches/reserved-stack-area.yml
+++ b/ms-patches/reserved-stack-area.yml
@@ -1,0 +1,8 @@
+title: Mark Reserved Stack Area as unsupported on Windows/ARM64
+- work_item: 3015480
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Mark Reserved Stack Area as unsupported on Windows/ARM64

--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -59,7 +59,9 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 // evidence that it's worth doing.
 #define DEOPTIMIZE_WHEN_PATCHING
 
+#if defined(LINUX) || defined(__APPLE__)
 #define SUPPORT_RESERVED_STACK_AREA
+#endif
 
 #if defined(__APPLE__) || defined(_WIN64)
 #define R18_RESERVED

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -48,7 +48,7 @@ define_pd_global(intx, OptoLoopAlignment,        16);
 // stack if compiled for unix and LP64. To pass stack overflow tests we need
 // 20 shadow pages.
 #define DEFAULT_STACK_SHADOW_PAGES (20 DEBUG_ONLY(+5))
-#define DEFAULT_STACK_RESERVED_PAGES (1)
+#define DEFAULT_STACK_RESERVED_PAGES (NOT_WINDOWS(1) WINDOWS_ONLY(0))
 
 #define MIN_STACK_YELLOW_PAGES DEFAULT_STACK_YELLOW_PAGES
 #define MIN_STACK_RED_PAGES    DEFAULT_STACK_RED_PAGES


### PR DESCRIPTION
This patch mimics the corresponding lines for Windows/x64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
