### PR TITLE
Add support for MSys2 for getinstance.sh and NotifyHandshakeTest.sh tests

### DIFF
--- a/ms-patches/msys2-fixes-3.yml
+++ b/ms-patches/msys2-fixes-3.yml
@@ -1,0 +1,8 @@
+title: Add support for MSys2 for getinstance.sh and NotifyHandshakeTest.sh tests
+- work_item: 3015471
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Add support for MSys2 for getinstance.sh and NotifyHandshakeTest.sh tests

--- a/test/jdk/sun/security/provider/PolicyFile/getinstance/getinstance.sh
+++ b/test/jdk/sun/security/provider/PolicyFile/getinstance/getinstance.sh
@@ -63,7 +63,7 @@ case "$OS" in
     PS=":"
     FS="/"
     ;;
-  CYGWIN* )
+  CYGWIN* | MSYS* | MINGW* )
     PS=";"
     FS="/"
     ;;

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh
@@ -51,7 +51,7 @@ case "$OS" in
         PATHSEP=":"
         ;;
 
-    CYGWIN* )
+    CYGWIN* | MSYS* | MINGW* )
         FILESEP="/"
         PATHSEP=";"
         ;;


### PR DESCRIPTION

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
