### PR TITLE
Remove SOEDeeplyNestedBlocksTest.java patch

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -34,7 +34,6 @@ active-patches:
   - ms-patches/multiple-logins
   - ms-patches/processor-api
   - ms-patches/reserved-stack-area
-  - ms-patches/stack-overflow-javac
   - ms-patches/win-aarch64-TestTrampoline
 
 


### PR DESCRIPTION
This patch from https://github.com/microsoft/openjdk-jdk21u/pull/49 changes the public compiler API

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
